### PR TITLE
[FEAT] FlexBox에 margin, padding 프롭 추가

### DIFF
--- a/src/components/common/FlexBox/FlexBox.stories.tsx
+++ b/src/components/common/FlexBox/FlexBox.stories.tsx
@@ -20,6 +20,8 @@ export const Basic: Story = {
     alignItem: 'center',
     justifyContent: 'center',
     flexWrap: 'nowrap',
+    margin: 0,
+    padding: 0,
   },
   argTypes: {
     flexDir: {
@@ -47,6 +49,12 @@ export const Basic: Story = {
     flexWrap: {
       control: { type: 'inline-radio' },
       options: ['nowrap', 'wrap', 'wrap-reverse'],
+    },
+    margin: {
+      control: { type: 'number' },
+    },
+    padding: {
+      control: { type: 'number' },
     },
   },
   render: (args) => (

--- a/src/components/common/FlexBox/FlexBox.styled.ts
+++ b/src/components/common/FlexBox/FlexBox.styled.ts
@@ -9,4 +9,6 @@ export const StyledFlexBox = styled.div<Props>`
   align-items: ${({ alignItem = 'center' }) => alignItem};
   justify-content: ${({ justifyContent = 'center' }) => justifyContent};
   flex-wrap: ${({ flexWrap = 'nowrap' }) => flexWrap};
+  margin: ${({ margin = 0 }) => (typeof margin === 'number' ? `${margin}px` : margin)};
+  padding: ${({ padding = 0 }) => (typeof padding === 'number' ? `${padding}px` : padding)};
 `;

--- a/src/components/common/FlexBox/FlexBox.types.ts
+++ b/src/components/common/FlexBox/FlexBox.types.ts
@@ -1,4 +1,4 @@
-import { ComponentPropsWithRef } from 'react';
+import { ComponentPropsWithoutRef } from 'react';
 
 export type Props = {
   /**
@@ -28,4 +28,14 @@ export type Props = {
    * @default 'nowrap'
    */
   flexWrap?: 'nowrap' | 'wrap' | 'wrap-reverse';
-} & ComponentPropsWithRef<'div'>;
+  /**
+   * @default 0
+   * @description number를 입력하면 px로, string을 입력하면 그대로 적용됩니다.
+   */
+  margin?: number | string;
+  /**
+   * @default 0
+   * @description number를 입력하면 px로, string을 입력하면 그대로 적용됩니다.
+   */
+  padding?: number | string;
+} & ComponentPropsWithoutRef<'div'>;


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #23 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

- FlexBox에 margin과 padding을 쉽게 적용할 수 있도록 프롭을 추가합니다.
  ```tsx
  <FlexBox margin={5} /> // 숫자만 입력 시 px로 변환 -> margin: '5px'
  <FlexBox margin='5px 10px' /> // 문자열로 입력 시 그대로 적용 -> margin: '5px 10px'
  // padding 도 동일
  ```

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
