### PR TITLE
[FEAT] Button에 padding props 추가

### DIFF
--- a/src/components/common/Button/Button.stories.tsx
+++ b/src/components/common/Button/Button.stories.tsx
@@ -14,30 +14,32 @@ export default meta;
 type Story = StoryObj<typeof Button>;
 
 export const Basic: Story = {
-  args: {
-    variant: 'primary',
-    width: 'full',
-    disabled: false,
-  },
-  argTypes: {
-    variant: {
-      control: { type: 'radio' },
-      options: ['primary'], // 예시 옵션, 실제 Button 컴포넌트에 맞게 조정. 추후에 secondary 추가 예정
-    },
-    width: {
-      control: { type: 'radio' },
-      options: ['full', 'fit'], // 예시 옵션, 실제 Button 컴포넌트에 맞게 조정
-    },
-    disabled: {
-      control: { type: 'boolean' },
-    },
-  },
-  render: (args) => (
-    <FlexBox flexDir="column" gap={8} alignItem="center">
-      <Button {...args}>버튼</Button>
-      <Button {...args} disabled>
-        버튼
-      </Button>
+  render: () => (
+    <FlexBox flexDir="row" gap={10}>
+      <FlexBox flexDir="column" gap={8} alignItem="center">
+        <Button variant="primary" padding="17px 159px">
+          다음
+        </Button>
+        <Button variant="primary" padding="17px 159px" disabled>
+          다음
+        </Button>
+      </FlexBox>
+      <FlexBox flexDir="column" gap={8} alignItem="center">
+        <Button variant="primary" padding="17px 30px">
+          일정 생성하기
+        </Button>
+        <Button variant="primary" padding="17px 30px" disabled>
+          일정 생성하기
+        </Button>
+      </FlexBox>
+      <FlexBox flexDir="column" gap={8} alignItem="center">
+        <Button variant="primary" padding="17px 49.5px">
+          돌아가기
+        </Button>
+        <Button variant="primary" padding="17px 49.5px" disabled>
+          돌아가기
+        </Button>
+      </FlexBox>
     </FlexBox>
   ),
 };

--- a/src/components/common/Button/Button.styled.ts
+++ b/src/components/common/Button/Button.styled.ts
@@ -7,7 +7,7 @@ import { Props } from './Button.types';
 export const StyledButton = styled.button<Props>`
   width: ${({ width = 'fit-content' }) => (width === 'full' ? '100%' : 'fit-content')};
   height: 62px;
-  padding: 17px 159px;
+  padding: ${({ padding = 0 }) => (typeof padding === 'number' ? `${padding}px` : padding)};
   transition: background-color 0.3s;
   border: none;
   cursor: pointer;

--- a/src/components/common/Button/Button.types.ts
+++ b/src/components/common/Button/Button.types.ts
@@ -1,4 +1,4 @@
-import { ButtonHTMLAttributes } from 'react';
+import { ButtonHTMLAttributes, ComponentPropsWithRef } from 'react';
 
 export type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
   /**
@@ -12,6 +12,12 @@ export type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
    */
   width?: 'full' | 'fit';
   /**
+   * Button padding style.
+   * @default 0
+   * @example 8, '8px', '8px 16px', '8px 16px 24px 32px'
+   */
+  padding?: number | string;
+  /**
    * Disabled state of the button.
    * @default 'false'
    */
@@ -20,4 +26,4 @@ export type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
    * Optional children for the button, typically a string.
    */
   children?: React.ReactNode;
-};
+} & ComponentPropsWithRef<'button'>;


### PR DESCRIPTION
## 관련 이슈

close #29 

## ✨ 작업 내용

- Button 컴포넌트에 padding props 추가했습니다. 
- padding 속성에 단일 값이 들어간다면 `padding={10}` 과 같이 사용이 가능하지만, 단일 값이 아닌 상하, 좌우 값이 따로 들어간다면 `padding="14px 18px"` 처럼 문자열로 작성해주셔야 합니다!


## 🙏 기타 참고 사항
