### PR TITLE
[FEAT] Progress 컴포넌트, 스토리북

### DIFF
--- a/src/components/common/Progress/Progress.stories.tsx
+++ b/src/components/common/Progress/Progress.stories.tsx
@@ -20,13 +20,13 @@ export const Basic: Story = {
   },
   argTypes: {
     min: {
-      control: { type: 'number', min: 0, max: 10, step: 1 },
+      control: { type: 'number', min: 0, max: 8, step: 1 },
     },
     max: {
-      control: { type: 'number', min: 0, max: 10, step: 1 },
+      control: { type: 'number', min: 0, max: 8, step: 1 },
     },
     value: {
-      control: { type: 'number', min: 0, max: 10, step: 1 },
+      control: { type: 'number', min: 0, max: 8, step: 1 },
     },
   },
   render: (args) => <Progress {...args} />,

--- a/src/components/common/Progress/Progress.stories.tsx
+++ b/src/components/common/Progress/Progress.stories.tsx
@@ -15,18 +15,18 @@ type Story = StoryObj<typeof Progress>;
 export const Basic: Story = {
   args: {
     min: 0,
-    max: 8,
+    max: 6,
     value: 1,
   },
   argTypes: {
     min: {
-      control: { type: 'number', min: 0, max: 8, step: 1 },
+      control: { type: 'number', min: 0, max: 6, step: 1 },
     },
     max: {
-      control: { type: 'number', min: 0, max: 8, step: 1 },
+      control: { type: 'number', min: 0, max: 6, step: 1 },
     },
     value: {
-      control: { type: 'number', min: 0, max: 8, step: 1 },
+      control: { type: 'number', min: 0, max: 6, step: 1 },
     },
   },
   render: (args) => <Progress {...args} />,

--- a/src/components/common/Progress/Progress.stories.tsx
+++ b/src/components/common/Progress/Progress.stories.tsx
@@ -1,0 +1,33 @@
+/* eslint-disable no-restricted-exports */
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Progress } from '.';
+
+const meta = {
+  title: 'components/common/Progress',
+  component: Progress,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Progress>;
+
+export default meta;
+type Story = StoryObj<typeof Progress>;
+
+export const Basic: Story = {
+  args: {
+    min: 0,
+    max: 8,
+    value: 1,
+  },
+  argTypes: {
+    min: {
+      control: { type: 'number', min: 0, max: 10, step: 1 },
+    },
+    max: {
+      control: { type: 'number', min: 0, max: 10, step: 1 },
+    },
+    value: {
+      control: { type: 'number', min: 0, max: 10, step: 1 },
+    },
+  },
+  render: (args) => <Progress {...args} />,
+};

--- a/src/components/common/Progress/Progress.styled.ts
+++ b/src/components/common/Progress/Progress.styled.ts
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+
+import { colors } from '@/styles/global';
+
+import { Props } from './Progress.types';
+
+export const StyledProgress = styled.div<Props>`
+  width: 180px;
+  height: 6px;
+  border-radius: 5px;
+  background-color: ${colors.GY5};
+  overflow: hidden;
+  position: relative;
+
+  &::before {
+    content: '';
+    display: block;
+    height: 100%;
+    border-radius: 5px;
+    background-color: ${colors.purple};
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: ${({ value = 0, min = 0, max = 100 }) => `${((value - min) / (max - min)) * 100}%`};
+    transition: width 0.5s ease-out;
+  }
+`;

--- a/src/components/common/Progress/Progress.types.ts
+++ b/src/components/common/Progress/Progress.types.ts
@@ -5,15 +5,15 @@ export type Props = {
    * Minimum value of the progress.
    * @default 0
    */
-  min?: number;
+  min: number;
   /**
    * Maximum value of the progress.
    * @default 6
    */
-  max?: number;
+  max: number;
   /**
    * Current value of the progress.
    * @default 1
    */
-  value?: number;
+  value: number;
 } & ComponentPropsWithoutRef<'div'>;

--- a/src/components/common/Progress/Progress.types.ts
+++ b/src/components/common/Progress/Progress.types.ts
@@ -1,0 +1,19 @@
+import { ComponentPropsWithoutRef } from 'react';
+
+export type Props = {
+  /**
+   * Minimum value of the progress.
+   * @default 0
+   */
+  min?: number;
+  /**
+   * Maximum value of the progress.
+   * @default 10
+   */
+  max?: number;
+  /**
+   * Current value of the progress.
+   * @default 1
+   */
+  value?: number;
+} & ComponentPropsWithoutRef<'div'>;

--- a/src/components/common/Progress/Progress.types.ts
+++ b/src/components/common/Progress/Progress.types.ts
@@ -8,7 +8,7 @@ export type Props = {
   min?: number;
   /**
    * Maximum value of the progress.
-   * @default 10
+   * @default 6
    */
   max?: number;
   /**

--- a/src/components/common/Progress/index.tsx
+++ b/src/components/common/Progress/index.tsx
@@ -3,6 +3,6 @@ import { forwardRef } from 'react';
 import { StyledProgress } from './Progress.styled';
 import { Props } from './Progress.types';
 
-export const Progress = forwardRef<HTMLDivElement, Props>(({ ...props }, ref) => {
-  return <StyledProgress ref={ref} {...props} />;
+export const Progress = forwardRef<HTMLDivElement, Props>(({ min, max, value, ...props }, ref) => {
+  return <StyledProgress min={min} max={max} value={value} ref={ref} {...props} />;
 });

--- a/src/components/common/Progress/index.tsx
+++ b/src/components/common/Progress/index.tsx
@@ -1,0 +1,8 @@
+import { forwardRef } from 'react';
+
+import { StyledProgress } from './Progress.styled';
+import { Props } from './Progress.types';
+
+export const Progress = forwardRef<HTMLDivElement, Props>(({ ...props }, ref) => {
+  return <StyledProgress ref={ref} {...props} />;
+});


### PR DESCRIPTION
## 관련 이슈

close #11 

## ✨ 작업 내용

- progress 컴포넌트, 스토리북 구현
- value값이 오를 수록 progress가 채워지는 컴포넌트 입니다.
![Aug-06-2024 23-48-08](https://github.com/user-attachments/assets/9fed73e4-65eb-42c9-836f-a7a3a61c0e99)

## 🙏 기타 참고 사항

- 추후에 피그마 > 컴포넌트 페이지 내에 완성본 올라오면 수정하도록 하겠습니다!
