### PR TITLE
[FEAT] size 프롭에 width, height 레코드 타입 추가

### DIFF
--- a/src/components/common/Icon/Icon.stories.tsx
+++ b/src/components/common/Icon/Icon.stories.tsx
@@ -19,10 +19,12 @@ type Story = StoryObj<typeof Icon>;
 export const Basic: Story = {
   args: {
     color: 'BK',
+    size: 20,
   },
   argTypes: {
     name: { table: { disable: true } },
     color: { control: { type: 'select' }, options: colorNames },
+    size: { control: { type: 'number' } },
   },
   render: (args) => {
     return (

--- a/src/components/common/Icon/Icon.types.ts
+++ b/src/components/common/Icon/Icon.types.ts
@@ -11,5 +11,5 @@ export type Props = {
    * @description px 단위로 변환합니다.
    * @default 20
    */
-  size?: number;
+  size?: number | { width: number; height: number };
 } & React.SVGProps<SVGSVGElement>;

--- a/src/components/common/Icon/index.tsx
+++ b/src/components/common/Icon/index.tsx
@@ -5,7 +5,15 @@ import { Props } from './Icon.types';
 
 export const Icon = ({ name, color = 'BK', size = 20, ...props }: Props) => {
   const IconSVGComponent = IconMap[name];
-  const pxSize = `${size}px`;
+  const width = typeof size === 'number' ? size : size.width;
+  const height = typeof size === 'number' ? size : size.height;
 
-  return <IconSVGComponent color={colors[color]} width={pxSize} height={pxSize} {...props} />;
+  return (
+    <IconSVGComponent
+      color={colors[color]}
+      width={`${width}px`}
+      height={`${height}px`}
+      {...props}
+    />
+  );
 };


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #51 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

<img width="112" alt="스크린샷 2024-08-10 오전 2 36 25" src="https://github.com/user-attachments/assets/1be01e70-c774-4c98-9bda-65c4e6f72c37">

- 로고 같은 이미지의 경우 가로와 세로 높이가 달라 기존 Icon 컴포넌트 인터페이스로 대응할 수 없는 문제가 있어 width와 height를 각각 지정할 수 있도록 size 프롭에 타입을 추가합니다.

- as-is
```tsx
<Icon name='logo' size={20} />
```

- to-be
```tsx
<Icon name='logo' size={20} /> // OK
<Icon name='logo' size={{ width: 20, height: 10}} /> // OK
```

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
