### PR TITLE
[FEAT] Calendar 컴포넌트, 스토리북

### DIFF
--- a/src/components/common/Calendar/Calendar.stories.tsx
+++ b/src/components/common/Calendar/Calendar.stories.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable no-restricted-exports */
+import { useState } from 'react';
+import { css } from '@emotion/react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Dayjs } from 'dayjs';
+
+import { Calendar } from '.';
+
+const meta = {
+  title: 'components/common/Calendar',
+  component: Calendar,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Calendar>;
+
+export default meta;
+type Story = StoryObj<typeof Calendar>;
+
+export const Basic: Story = {
+  render: () => {
+    const [selectedStartDate, setSelectedStartDate] = useState<Dayjs | null>(null);
+    const [selectedEndDate, setSelectedEndDate] = useState<Dayjs | null>(null);
+
+    const handleDateChange = (start: Dayjs | null, end: Dayjs | null) => {
+      setSelectedStartDate(start);
+      setSelectedEndDate(end);
+    };
+    return (
+      <div css={css(`width: 393px; padding: 20px; background-color: #F6F6F6;`)}>
+        <Calendar
+          startDate={selectedStartDate}
+          endDate={selectedEndDate}
+          onDateChange={handleDateChange}
+        />
+      </div>
+    );
+  },
+};

--- a/src/components/common/Calendar/Calendar.styled.ts
+++ b/src/components/common/Calendar/Calendar.styled.ts
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled';
+
+import { colors } from '@/styles/global';
+
+import { ButtonProps } from './Calendar.types';
+
+export const StyledCalendarContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const StyledDateHeader = styled.div`
+  width: 100%;
+  height: 28px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 20px;
+  margin: 5px 0;
+`;
+
+export const StyledWeekHeader = styled.div`
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: center;
+  gap: 12px;
+  margin-top: 27px;
+  margin-bottom: 18px;
+  font-size: 16px;
+`;
+export const StyledDatesGrid = styled.div`
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: center;
+  place-items: center;
+  gap: 12px;
+`;
+
+export const StyledDateButton = styled.button<ButtonProps>`
+  width: 40px;
+  aspect-ratio: 1;
+  background-color: ${({ isSelected, isInRange }) =>
+    isSelected ? colors.purple : isInRange ? colors.purple : colors.WH};
+  border: none;
+  border-radius: 100%;
+  cursor: ${({ isDisabled }) => (isDisabled ? 'not-allowed' : 'pointer')};
+  font-size: 16px;
+  color: ${({ isSelected, isInRange }) =>
+    isSelected ? colors.WH : isInRange ? colors.WH : colors.BK};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  z-index: 1;
+`;

--- a/src/components/common/Calendar/Calendar.types.ts
+++ b/src/components/common/Calendar/Calendar.types.ts
@@ -1,0 +1,45 @@
+import { ComponentPropsWithoutRef } from 'react';
+import { Dayjs } from 'dayjs';
+
+export type Props = {
+  /**
+   * Start date for the selected range.
+   */
+  startDate: Dayjs | null;
+  /**
+   * End date for the selected range.
+   */
+  endDate: Dayjs | null;
+  /**
+   * Callback function for when the date is changed.
+   */
+  onDateChange: (start: Dayjs | null, end: Dayjs | null) => void;
+} & ComponentPropsWithoutRef<'div'>;
+
+export type ButtonProps = {
+  /**
+   * Whether the date is selected.
+   * @default false
+   */
+  isSelected: boolean;
+  /**
+   * Whether the date is in the selected range.
+   * @default false
+   */
+  isInRange: boolean;
+  /**
+   * Whether the date is the start of the selected range.
+   * @default false
+   */
+  isRangeStart: boolean;
+  /**
+   * Whether the date is the end of the selected range.
+   * @default false
+   */
+  isRangeEnd: boolean;
+  /**
+   * Whether the date is disabled.
+   * @default false
+   */
+  isDisabled: boolean;
+} & ComponentPropsWithoutRef<'button'>;

--- a/src/components/common/Calendar/index.tsx
+++ b/src/components/common/Calendar/index.tsx
@@ -1,0 +1,61 @@
+import { forwardRef } from 'react';
+import { css } from '@emotion/react';
+
+import {
+  StyledDateHeader,
+  StyledWeekHeader,
+  StyledCalendarContainer,
+  StyledDateButton,
+  StyledDatesGrid,
+} from './Calendar.styled';
+import { Props } from './Calendar.types';
+import { useCalendar } from './useCalendar';
+
+import { Icon } from '../Icon';
+
+export const Calendar = forwardRef<HTMLDivElement, Props>(
+  ({ startDate, endDate, onDateChange, ...props }, ref) => {
+    const { currentMonth, handleDateChange, handleDateSelect, generateDates, isCurrentMonth } =
+      useCalendar({ startDate, endDate, onDateChange });
+
+    return (
+      <StyledCalendarContainer ref={ref} {...props}>
+        <StyledDateHeader>
+          <Icon
+            name="left"
+            onClick={() => handleDateChange('prev')}
+            css={css`
+              cursor: pointer;
+              visibility: ${isCurrentMonth ? 'hidden' : 'visible'};
+            `}
+          />
+          {currentMonth.format('YYYY년 M월')}
+          <Icon
+            name="right"
+            onClick={() => handleDateChange('next')}
+            css={css`
+              cursor: pointer;
+            `}
+          />
+        </StyledDateHeader>
+        <StyledWeekHeader>
+          {['월', '화', '수', '목', '금', '토', '일'].map((day) => (
+            <div key={day}>{day}</div>
+          ))}
+        </StyledWeekHeader>
+        <StyledDatesGrid>
+          {generateDates().map(({ date, isCurrentMonth, isDisabled, ...props }) => (
+            <StyledDateButton
+              key={date.toString()}
+              isDisabled={isDisabled}
+              onClick={() => !isDisabled && isCurrentMonth && handleDateSelect(date)}
+              {...props}
+            >
+              {isCurrentMonth ? date.date() : ''}
+            </StyledDateButton>
+          ))}
+        </StyledDatesGrid>
+      </StyledCalendarContainer>
+    );
+  }
+);

--- a/src/components/common/Calendar/useCalendar.tsx
+++ b/src/components/common/Calendar/useCalendar.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
 
+import { CALENDAR } from '@/constants/calendar';
+
 import { Props } from './Calendar.types';
 
 export const useCalendar = ({ startDate, endDate, onDateChange }: Props) => {
@@ -9,9 +11,12 @@ export const useCalendar = ({ startDate, endDate, onDateChange }: Props) => {
   const today = dayjs().startOf('day');
   const currentMonthStart = dayjs().startOf('month');
 
-  const handleDateChange = (direction: string) => {
+  const handleDateChange = (direction: 'prev' | 'next') => {
     setCurrentMonth((prev) => {
-      const newMonth = direction === 'prev' ? prev.subtract(1, 'month') : prev.add(1, 'month');
+      const newMonth =
+        direction === 'prev'
+          ? prev.subtract(CALENDAR.MAX_MONTHS, 'month')
+          : prev.add(CALENDAR.MAX_MONTHS, 'month');
 
       return newMonth.isBefore(currentMonthStart) ? currentMonthStart : newMonth;
     });
@@ -42,12 +47,12 @@ export const useCalendar = ({ startDate, endDate, onDateChange }: Props) => {
       return;
     }
 
-    if (date.diff(startDate, 'day') <= 14) {
+    if (date.diff(startDate, 'day') <= CALENDAR.MAX_RANGE) {
       onDateChange(startDate, date);
       return;
     }
 
-    onDateChange(startDate, startDate.add(13, 'day'));
+    onDateChange(startDate, startDate.add(CALENDAR.MAX_RANGE, 'day'));
   };
 
   const isDateInRange = (date: dayjs.Dayjs, start: dayjs.Dayjs, end: dayjs.Dayjs) =>
@@ -55,9 +60,9 @@ export const useCalendar = ({ startDate, endDate, onDateChange }: Props) => {
 
   const isDateDisabled = (date: dayjs.Dayjs, today: dayjs.Dayjs, startDate: dayjs.Dayjs) =>
     date.isBefore(today) ||
-    date.isAfter(today.add(30, 'day')) ||
-    (startDate && date.isAfter(startDate.add(14, 'day'))) ||
-    (startDate && date.isBefore(startDate.subtract(14, 'day')));
+    date.isAfter(today.add(CALENDAR.MAX_MONTH_DAYS, 'day')) ||
+    (startDate && date.isAfter(startDate.add(CALENDAR.MAX_RANGE, 'day'))) ||
+    (startDate && date.isBefore(startDate.subtract(CALENDAR.MAX_RANGE, 'day')));
 
   const createDateObject = (currentDate: dayjs.Dayjs) => ({
     date: currentDate,
@@ -74,7 +79,7 @@ export const useCalendar = ({ startDate, endDate, onDateChange }: Props) => {
     const startOfMonth = currentMonth.startOf('month');
     const startDayOfWeek = startOfMonth.day();
 
-    return Array.from({ length: 35 }, (_, i) => {
+    return Array.from({ length: CALENDAR.TOTAL_DAYS }, (_, i) => {
       const currentDate = startOfMonth.add(i - startDayOfWeek, 'day');
       return createDateObject(currentDate);
     });

--- a/src/components/common/Calendar/useCalendar.tsx
+++ b/src/components/common/Calendar/useCalendar.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import dayjs, { Dayjs } from 'dayjs';
+
+import { Props } from './Calendar.types';
+
+export const useCalendar = ({ startDate, endDate, onDateChange }: Props) => {
+  const [currentMonth, setCurrentMonth] = useState(dayjs());
+
+  const today = dayjs().startOf('day');
+  const currentMonthStart = dayjs().startOf('month');
+
+  // 이전 달, 다음 달로 선택
+  const handleDateChange = (direction: string) => {
+    setCurrentMonth((prev) => {
+      const newMonth = direction === 'prev' ? prev.subtract(1, 'month') : prev.add(1, 'month');
+      // 현재 달보다 이전으로는 이동 불가
+      return newMonth.isBefore(currentMonthStart) ? currentMonthStart : newMonth;
+    });
+  };
+
+  const handleDateSelect = (date: Dayjs) => {
+    if (date.isBefore(today)) {
+      return;
+    }
+
+    if (!startDate) {
+      onDateChange(date, null);
+    } else if (startDate && !endDate) {
+      if (date.isSame(startDate, 'day')) {
+        onDateChange(null, null);
+      } else if (date.isAfter(startDate)) {
+        const dayDifference = date.diff(startDate, 'day');
+        if (dayDifference <= 14) {
+          onDateChange(startDate, date);
+        } else {
+          onDateChange(startDate, startDate.add(13, 'day'));
+        }
+      } else {
+        onDateChange(date, startDate);
+      }
+    } else if (startDate && endDate) {
+      if (date.isSame(endDate, 'day')) {
+        onDateChange(startDate, null);
+      } else {
+        onDateChange(date, null);
+      }
+    }
+  };
+
+  const generateDates = () => {
+    const dates = [];
+    const startOfMonth = currentMonth.startOf('month'); // 현재 달의 시작일
+    const startDayOfWeek = startOfMonth.day(); // 현재 달의 시작 요일
+
+    for (let i = 0; i < 35; i++) {
+      const currentDate = startOfMonth.add(i - startDayOfWeek, 'day'); // 현재 달의 날짜
+      const isCurrentMonth = currentDate.isSame(currentMonth, 'month'); // 현재 달인지 확인
+
+      const isSelected =
+        currentDate.isSame(startDate, 'day') || (endDate && currentDate.isSame(endDate, 'day')); // 선택된 날짜인지 확인
+      const isInRange =
+        startDate &&
+        endDate &&
+        currentDate.isAfter(startDate, 'day') &&
+        currentDate.isBefore(endDate, 'day'); // 선택된 범위인지 확인
+      const isRangeStart = startDate && currentDate.isSame(startDate, 'day'); // 선택된 범위의 시작일인지 확인
+      const isRangeEnd = endDate && currentDate.isSame(endDate, 'day'); // 선택된 범위의 마지막일인지 확인
+      const isDisabled =
+        currentDate.isBefore(today) ||
+        currentDate.isAfter(today.add(30, 'day')) ||
+        (startDate && currentDate.isAfter(startDate.add(14, 'day'))); // 선택 불가능한 날짜인지 확인
+
+      dates.push({
+        date: currentDate,
+        isCurrentMonth,
+        isSelected: isSelected || false,
+        isInRange: isInRange || false,
+        isRangeStart: isRangeStart || false,
+        isRangeEnd: isRangeEnd || false,
+        isDisabled: isDisabled || false,
+      });
+    }
+
+    return dates;
+  };
+
+  return {
+    currentMonth,
+    handleDateChange,
+    handleDateSelect,
+    generateDates,
+    isCurrentMonth: currentMonth.isSame(currentMonthStart, 'month'),
+  };
+};

--- a/src/components/common/Calendar/useCalendar.tsx
+++ b/src/components/common/Calendar/useCalendar.tsx
@@ -9,11 +9,10 @@ export const useCalendar = ({ startDate, endDate, onDateChange }: Props) => {
   const today = dayjs().startOf('day');
   const currentMonthStart = dayjs().startOf('month');
 
-  // 이전 달, 다음 달로 선택
   const handleDateChange = (direction: string) => {
     setCurrentMonth((prev) => {
       const newMonth = direction === 'prev' ? prev.subtract(1, 'month') : prev.add(1, 'month');
-      // 현재 달보다 이전으로는 이동 불가
+
       return newMonth.isBefore(currentMonthStart) ? currentMonthStart : newMonth;
     });
   };
@@ -25,36 +24,40 @@ export const useCalendar = ({ startDate, endDate, onDateChange }: Props) => {
 
     if (!startDate) {
       onDateChange(date, null);
-    } else if (startDate && !endDate) {
-      if (date.isSame(startDate, 'day')) {
-        onDateChange(null, null);
-      } else if (date.isAfter(startDate)) {
-        const dayDifference = date.diff(startDate, 'day');
-        if (dayDifference <= 14) {
-          onDateChange(startDate, date);
-        } else {
-          onDateChange(startDate, startDate.add(13, 'day'));
-        }
-      } else {
-        onDateChange(date, startDate);
-      }
-    } else if (startDate && endDate) {
-      if (date.isSame(endDate, 'day')) {
-        onDateChange(startDate, null);
-      } else {
-        onDateChange(date, null);
-      }
+      return;
     }
+
+    if (endDate) {
+      onDateChange(date.isSame(endDate, 'day') ? startDate : date, null);
+      return;
+    }
+
+    if (date.isSame(startDate, 'day')) {
+      onDateChange(null, null);
+      return;
+    }
+
+    if (!date.isAfter(startDate)) {
+      onDateChange(date, startDate);
+      return;
+    }
+
+    if (date.diff(startDate, 'day') <= 14) {
+      onDateChange(startDate, date);
+      return;
+    }
+
+    onDateChange(startDate, startDate.add(13, 'day'));
   };
 
   const generateDates = () => {
     const dates = [];
-    const startOfMonth = currentMonth.startOf('month'); // 현재 달의 시작일
-    const startDayOfWeek = startOfMonth.day(); // 현재 달의 시작 요일
+    const startOfMonth = currentMonth.startOf('month');
+    const startDayOfWeek = startOfMonth.day();
 
     for (let i = 0; i < 35; i++) {
-      const currentDate = startOfMonth.add(i - startDayOfWeek, 'day'); // 현재 달의 날짜
-      const isCurrentMonth = currentDate.isSame(currentMonth, 'month'); // 현재 달인지 확인
+      const currentDate = startOfMonth.add(i - startDayOfWeek, 'day');
+      const isCurrentMonth = currentDate.isSame(currentMonth, 'month');
 
       const isSelected =
         currentDate.isSame(startDate, 'day') || (endDate && currentDate.isSame(endDate, 'day')); // 선택된 날짜인지 확인
@@ -62,13 +65,13 @@ export const useCalendar = ({ startDate, endDate, onDateChange }: Props) => {
         startDate &&
         endDate &&
         currentDate.isAfter(startDate, 'day') &&
-        currentDate.isBefore(endDate, 'day'); // 선택된 범위인지 확인
-      const isRangeStart = startDate && currentDate.isSame(startDate, 'day'); // 선택된 범위의 시작일인지 확인
-      const isRangeEnd = endDate && currentDate.isSame(endDate, 'day'); // 선택된 범위의 마지막일인지 확인
+        currentDate.isBefore(endDate, 'day');
+      const isRangeStart = startDate && currentDate.isSame(startDate, 'day');
+      const isRangeEnd = endDate && currentDate.isSame(endDate, 'day');
       const isDisabled =
         currentDate.isBefore(today) ||
         currentDate.isAfter(today.add(30, 'day')) ||
-        (startDate && currentDate.isAfter(startDate.add(14, 'day'))); // 선택 불가능한 날짜인지 확인
+        (startDate && currentDate.isAfter(startDate.add(14, 'day')));
 
       dates.push({
         date: currentDate,

--- a/src/components/common/Calendar/useCalendar.tsx
+++ b/src/components/common/Calendar/useCalendar.tsx
@@ -67,12 +67,14 @@ export const useCalendar = ({ startDate, endDate, onDateChange }: Props) => {
   const createDateObject = (currentDate: dayjs.Dayjs) => ({
     date: currentDate,
     isCurrentMonth: currentDate.isSame(currentMonth, 'month'),
-    isSelected:
-      currentDate.isSame(startDate, 'day') || (endDate && currentDate.isSame(endDate, 'day')),
-    isInRange: startDate && endDate && isDateInRange(currentDate, startDate, endDate),
-    isRangeStart: startDate && currentDate.isSame(startDate, 'day'),
-    isRangeEnd: endDate && currentDate.isSame(endDate, 'day'),
-    isDisabled: startDate && isDateDisabled(currentDate, today, startDate),
+    isSelected: !!(
+      currentDate.isSame(startDate, 'day') ||
+      (endDate && currentDate.isSame(endDate, 'day'))
+    ),
+    isInRange: !!(startDate && endDate && isDateInRange(currentDate, startDate, endDate)),
+    isRangeStart: !!(startDate && currentDate.isSame(startDate, 'day')),
+    isRangeEnd: !!(endDate && currentDate.isSame(endDate, 'day')),
+    isDisabled: !!(startDate && isDateDisabled(currentDate, today, startDate)),
   });
 
   const generateDates = () => {

--- a/src/components/common/Calendar/useCalendar.tsx
+++ b/src/components/common/Calendar/useCalendar.tsx
@@ -50,41 +50,34 @@ export const useCalendar = ({ startDate, endDate, onDateChange }: Props) => {
     onDateChange(startDate, startDate.add(13, 'day'));
   };
 
+  const isDateInRange = (date: dayjs.Dayjs, start: dayjs.Dayjs, end: dayjs.Dayjs) =>
+    start && end && date.isAfter(start, 'day') && date.isBefore(end, 'day');
+
+  const isDateDisabled = (date: dayjs.Dayjs, today: dayjs.Dayjs, startDate: dayjs.Dayjs) =>
+    date.isBefore(today) ||
+    date.isAfter(today.add(30, 'day')) ||
+    (startDate && date.isAfter(startDate.add(14, 'day'))) ||
+    (startDate && date.isBefore(startDate.subtract(14, 'day')));
+
+  const createDateObject = (currentDate: dayjs.Dayjs) => ({
+    date: currentDate,
+    isCurrentMonth: currentDate.isSame(currentMonth, 'month'),
+    isSelected:
+      currentDate.isSame(startDate, 'day') || (endDate && currentDate.isSame(endDate, 'day')),
+    isInRange: startDate && endDate && isDateInRange(currentDate, startDate, endDate),
+    isRangeStart: startDate && currentDate.isSame(startDate, 'day'),
+    isRangeEnd: endDate && currentDate.isSame(endDate, 'day'),
+    isDisabled: startDate && isDateDisabled(currentDate, today, startDate),
+  });
+
   const generateDates = () => {
-    const dates = [];
     const startOfMonth = currentMonth.startOf('month');
     const startDayOfWeek = startOfMonth.day();
 
-    for (let i = 0; i < 35; i++) {
+    return Array.from({ length: 35 }, (_, i) => {
       const currentDate = startOfMonth.add(i - startDayOfWeek, 'day');
-      const isCurrentMonth = currentDate.isSame(currentMonth, 'month');
-
-      const isSelected =
-        currentDate.isSame(startDate, 'day') || (endDate && currentDate.isSame(endDate, 'day')); // 선택된 날짜인지 확인
-      const isInRange =
-        startDate &&
-        endDate &&
-        currentDate.isAfter(startDate, 'day') &&
-        currentDate.isBefore(endDate, 'day');
-      const isRangeStart = startDate && currentDate.isSame(startDate, 'day');
-      const isRangeEnd = endDate && currentDate.isSame(endDate, 'day');
-      const isDisabled =
-        currentDate.isBefore(today) ||
-        currentDate.isAfter(today.add(30, 'day')) ||
-        (startDate && currentDate.isAfter(startDate.add(14, 'day')));
-
-      dates.push({
-        date: currentDate,
-        isCurrentMonth,
-        isSelected: isSelected || false,
-        isInRange: isInRange || false,
-        isRangeStart: isRangeStart || false,
-        isRangeEnd: isRangeEnd || false,
-        isDisabled: isDisabled || false,
-      });
-    }
-
-    return dates;
+      return createDateObject(currentDate);
+    });
   };
 
   return {

--- a/src/constants/calendar.ts
+++ b/src/constants/calendar.ts
@@ -1,0 +1,6 @@
+export const CALENDAR = {
+  MAX_MONTHS: 1,
+  MAX_RANGE: 14,
+  MAX_MONTH_DAYS: 30,
+  TOTAL_DAYS: 35,
+};


### PR DESCRIPTION
## 관련 이슈

close #12 

## ✨ 작업 내용

- Calendar 스토리북, 컴포넌트 구현하였습니다.
- 선택 불가능한 경우는 다음과 같습니다.
1. 이전 달
2. 오늘 이전
3. 오늘로부터 한달 뒤 (선택한 날짜가 없을 경우)
4. 오늘로부터 14일 이후 (선택한 날짜가 있을 경우)

<img width="400" alt="image" src="https://github.com/user-attachments/assets/06fd8b11-ee0a-41f8-83f2-e899ee4543c7">


## 🙏 기타 참고 사항

- 디자인 사항이 2개라 날짜와 날짜 사이 배경 이미지색 입히는 건 추후에 진행하도록 하겠습니다...!
- 버튼이 피그마-컴포넌트에 있는 버튼하고 살짝 다른 것 같습니다! left, right 버튼 버전이 2개인지 여쭤봐야 할 것 같습니당
