### PR TITLE
[REFACTOR] TextField에서 불필요한 상태 제거

### DIFF
--- a/src/components/common/TextField/TextField.stories.tsx
+++ b/src/components/common/TextField/TextField.stories.tsx
@@ -2,6 +2,8 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { createIsInvalidInstance, createIsValidInstance } from '@/utils/validation';
+
 import { TextField } from '.';
 
 const meta = {
@@ -35,11 +37,11 @@ export const Basic: Story = {
   },
   render: (args) => {
     const [value, setValue] = useState('');
-    const validator = (target: string) => {
-      if (target.length > 10) {
-        return { isValid: false, message: '10글자까지 입력 가능합니다.' };
+    const validator = (value: string) => {
+      if (value.length > 10) {
+        return createIsInvalidInstance('10글자까지 입력 가능합니다.');
       }
-      return { isValid: true };
+      return createIsValidInstance();
     };
 
     const handleChange = (newValue: string) => {

--- a/src/components/common/TextField/TextField.types.ts
+++ b/src/components/common/TextField/TextField.types.ts
@@ -1,5 +1,7 @@
 import { ComponentPropsWithoutRef } from 'react';
 
+import { InvalidState, ValidState } from '@/utils/validation';
+
 export type Props = ComponentPropsWithoutRef<'input'> & {
   value?: string;
   /**
@@ -19,12 +21,4 @@ export type Props = ComponentPropsWithoutRef<'input'> & {
    * @example onClickClear={() => setValue('')}
    */
   onClickClear?: () => void;
-};
-
-export type ValidState = {
-  isValid: true;
-};
-export type InvalidState = {
-  isValid: false;
-  message?: string;
 };

--- a/src/components/common/TextField/index.tsx
+++ b/src/components/common/TextField/index.tsx
@@ -1,34 +1,30 @@
-import { ChangeEvent, forwardRef, useState } from 'react';
+import { ChangeEvent, forwardRef } from 'react';
 import { css } from '@emotion/react';
 
 import { IconButton } from '@/components/common/IconButton';
 import { Caption } from '@/components/common/Typography';
 import { colors } from '@/styles/global';
+import { createIsValidInstance } from '@/utils/validation';
 
 import { StyledInput, StyledTextFieldContainer, StyledTextFieldWrapper } from './TextField.styled';
-import { InvalidState, Props, ValidState } from './TextField.types';
+import { Props } from './TextField.types';
 
 export const TextField = forwardRef<HTMLInputElement, Props>(
   (
     { variant = 'filled', value, disabled, validator, onChange, onClickClear, ...inputProps },
     ref
   ) => {
-    const [validState, setValidState] = useState<ValidState | InvalidState>({ isValid: true });
     const hasInput = value ? value.length > 0 : false;
-    const isInvalidInput = validState.isValid === false;
+    const validationState = validator && value ? validator(value) : createIsValidInstance(); // NOTE: validator가 없으면 항상 유효한 상태로 간주
     const canShowClearButton = hasInput && onClickClear && !disabled;
 
     const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-      if (validator) {
-        setValidState(validator(e.target.value));
-      }
       if (onChange) {
         onChange(e);
       }
     };
 
     const handleClickClear = () => {
-      setValidState({ isValid: true });
       if (onClickClear) {
         onClickClear();
       }
@@ -39,7 +35,7 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
         <StyledTextFieldWrapper
           variant={variant}
           style={
-            isInvalidInput
+            validationState.isValid === false
               ? { outline: `1px solid ${colors.RD}`, ...inputProps.style }
               : inputProps.style
           }
@@ -55,9 +51,9 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
             <IconButton iconName="deleteRounded" size={14} onClick={handleClickClear} css={css``} />
           )}
         </StyledTextFieldWrapper>
-        {isInvalidInput && (
+        {validationState.isValid === false && (
           <Caption color="RD" regularWeight>
-            {validState.message || '올바른 값을 입력해 주세요.'}
+            {validationState.message || '올바른 값을 입력해 주세요.'}
           </Caption>
         )}
       </StyledTextFieldContainer>

--- a/src/components/common/TextField/index.tsx
+++ b/src/components/common/TextField/index.tsx
@@ -51,6 +51,7 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
             <IconButton iconName="deleteRounded" size={14} onClick={handleClickClear} css={css``} />
           )}
         </StyledTextFieldWrapper>
+        {/* TODO valid 헬퍼 필요한 경우 대응 */}
         {validationState.isValid === false && (
           <Caption color="RD" regularWeight>
             {validationState.message || '올바른 값을 입력해 주세요.'}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,13 @@
+export type ValidState = {
+  isValid: true;
+};
+export type InvalidState = {
+  isValid: false;
+  message?: string;
+};
+
+export const createIsValidInstance: () => ValidState = () => ({ isValid: true });
+export const createIsInvalidInstance: (message?: string) => InvalidState = (message) => ({
+  isValid: false,
+  message,
+});


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #101 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

- input 값의 유효 상태를 다루기위해 둔 validState를 다음과 같은 이유로 제거합니다.
  - onChange 핸들러가 호출될 때 계산으로 얻을 수 있는 상태 -> useState로 관리할 필요 없음

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
