### PR TITLE
[FEAT] 모임 생성 폼 상태 정리

### DIFF
--- a/src/components/features/CreateMeetingForm/AnonymousForm.tsx
+++ b/src/components/features/CreateMeetingForm/AnonymousForm.tsx
@@ -5,14 +5,17 @@ import { FlexBox } from '@/components/common/FlexBox';
 import { FormLayout } from '@/components/common/FormLayout';
 import { Switch } from '@/components/common/Switch';
 import { useFunnelProgressContext } from '@/hooks/useFunnelProgressContext';
+import { MeetingForm } from '@/types/meeting';
 
-import { CreateMeetingFormBaseProps } from './types';
+import { CreateMeetingFormBaseProps, FormData } from './types';
 
-type Props = CreateMeetingFormBaseProps;
+type Props<T> = CreateMeetingFormBaseProps & FormData<T>;
 
-export const AnonymousForm = ({ onNext, onPrev }: Props) => {
+export const AnonymousForm = ({ context, onNext, onPrev }: Props<MeetingForm['isAnonymous']>) => {
   const { progress, maxProgress } = useFunnelProgressContext();
-  const [isAnonymous, setIsAnonymous] = useState(false);
+  const { state: isAnonymousFormData, setState: setIsAnonymousFormData } = context;
+
+  const [isAnonymous, setIsAnonymous] = useState(isAnonymousFormData);
 
   return (
     <>
@@ -37,7 +40,14 @@ export const AnonymousForm = ({ onNext, onPrev }: Props) => {
           </FlexBox>
         }
       />
-      <FixedBottomButton onClick={onNext}>다음</FixedBottomButton>
+      <FixedBottomButton
+        onClick={() => {
+          onNext();
+          setIsAnonymousFormData(isAnonymous);
+        }}
+      >
+        다음
+      </FixedBottomButton>
     </>
   );
 };

--- a/src/components/features/CreateMeetingForm/CategoryForm.tsx
+++ b/src/components/features/CreateMeetingForm/CategoryForm.tsx
@@ -51,7 +51,7 @@ export const CategoryForm = ({ context, onNext, onPrev }: Props<MeetingForm['cat
                   key={category}
                   component="button"
                   variant={
-                    selectedCategoryIds.includes(categoryIdMap[category]) ? 'filled' : 'dimmed'
+                    selectedCategoryIds.includes(categoryIdMap[category]) ? 'primary' : 'dimmed'
                   }
                   value={categoryIdMap[category]}
                   onClick={() => handleClickChip(categoryIdMap[category])}

--- a/src/components/features/CreateMeetingForm/CategoryForm.tsx
+++ b/src/components/features/CreateMeetingForm/CategoryForm.tsx
@@ -4,33 +4,37 @@ import { Chip } from '@/components/common/Chip';
 import { FixedBottomButton } from '@/components/common/FixedBottomButton';
 import { FlexBox } from '@/components/common/FlexBox';
 import { FormLayout } from '@/components/common/FormLayout';
-import { categories } from '@/constants/meetingForm';
+import { categories, categoryIdMap } from '@/constants/meetingForm';
 import { useFunnelProgressContext } from '@/hooks/useFunnelProgressContext';
+import { MeetingForm } from '@/types/meeting';
 
-import { CreateMeetingFormBaseProps } from './types';
+import { CreateMeetingFormBaseProps, FormData } from './types';
 
-type Props = CreateMeetingFormBaseProps;
+type Props<T> = CreateMeetingFormBaseProps & FormData<T>;
 
 const MIN_SELECT_COUNT = 1;
 const MAX_SELECT_COUNT = 3;
 
-export const CategoryForm = ({ onNext, onPrev }: Props) => {
+export const CategoryForm = ({ context, onNext, onPrev }: Props<MeetingForm['categoryIds']>) => {
   const { progress, maxProgress } = useFunnelProgressContext();
-  const [selectedCategory, setSelectedCategory] = useState<string[]>([]);
+  const { state: categoryIdsFormData, setState: setCategoryIdsFormData } = context;
 
-  const canClick = (chipValue: string) => {
+  const [selectedCategoryIds, setSelectedCategoryIds] = useState<number[]>(categoryIdsFormData);
+
+  const canClick = (chipValue: number) => {
     return (
-      (!selectedCategory.includes(chipValue) && selectedCategory.length < MAX_SELECT_COUNT) ||
-      (selectedCategory.includes(chipValue) && selectedCategory.length === MAX_SELECT_COUNT) ||
-      selectedCategory.length < MAX_SELECT_COUNT
+      (!selectedCategoryIds.includes(chipValue) && selectedCategoryIds.length < MAX_SELECT_COUNT) ||
+      (selectedCategoryIds.includes(chipValue) &&
+        selectedCategoryIds.length === MAX_SELECT_COUNT) ||
+      selectedCategoryIds.length < MAX_SELECT_COUNT
     );
   };
 
-  const handleClickChip = (chipValue: string) => {
+  const handleClickChip = (chipValue: number) => {
     if (!canClick(chipValue)) return;
-    return selectedCategory.includes(chipValue)
-      ? setSelectedCategory(selectedCategory.filter((selected) => selected !== chipValue))
-      : setSelectedCategory([...selectedCategory, chipValue]);
+    return selectedCategoryIds.includes(chipValue)
+      ? setSelectedCategoryIds(selectedCategoryIds.filter((selected) => selected !== chipValue))
+      : setSelectedCategoryIds([...selectedCategoryIds, chipValue]);
   };
 
   return (
@@ -46,9 +50,12 @@ export const CategoryForm = ({ onNext, onPrev }: Props) => {
                 <Chip
                   key={category}
                   component="button"
-                  variant={selectedCategory.includes(category) ? 'primary' : 'dimmed'}
-                  onClick={() => handleClickChip(category)}
-                  disabled={!canClick(category)}
+                  variant={
+                    selectedCategoryIds.includes(categoryIdMap[category]) ? 'filled' : 'dimmed'
+                  }
+                  value={categoryIdMap[category]}
+                  onClick={() => handleClickChip(categoryIdMap[category])}
+                  disabled={!canClick(categoryIdMap[category])}
                 >
                   {category}
                 </Chip>
@@ -58,8 +65,11 @@ export const CategoryForm = ({ onNext, onPrev }: Props) => {
         }
       />
       <FixedBottomButton
-        disabled={selectedCategory.length < MIN_SELECT_COUNT}
-        onClick={() => onNext(selectedCategory)}
+        disabled={selectedCategoryIds.length < MIN_SELECT_COUNT}
+        onClick={() => {
+          onNext();
+          setCategoryIdsFormData(selectedCategoryIds);
+        }}
       >
         다음
       </FixedBottomButton>

--- a/src/components/features/CreateMeetingForm/CreateMeetingForm.stories.tsx
+++ b/src/components/features/CreateMeetingForm/CreateMeetingForm.stories.tsx
@@ -32,13 +32,18 @@ export const Basic: Story = {
       <AppLayout>
         <Funnel>
           <Funnel.Step name="카테고리">
-            <CategoryForm onPrev={() => {}} onNext={() => setStep('모임이름')} />
+            <CategoryForm
+              onPrev={() => {}}
+              onNext={() => setStep('모임이름')}
+              context={{ state: [], setState: () => {} }}
+            />
           </Funnel.Step>
 
           <Funnel.Step name="모임이름">
             <MeetingNameForm
               onPrev={() => setStep('카테고리')}
               onNext={() => setStep('일정수집기한')}
+              context={{ state: '', setState: () => {} }}
             />
           </Funnel.Step>
 
@@ -46,6 +51,7 @@ export const Basic: Story = {
             <MeetingDateRangeForm
               onPrev={() => setStep('모임이름')}
               onNext={() => setStep('모임인원수')}
+              context={{ state: { meetingStartDate: '', meetingEndDate: '' }, setState: () => {} }}
             />
           </Funnel.Step>
 
@@ -53,6 +59,7 @@ export const Basic: Story = {
             <MemberCountForm
               onPrev={() => setStep('일정수집기한')}
               onNext={() => setStep('익명여부')}
+              context={{ state: 0, setState: () => {} }}
             />
           </Funnel.Step>
 
@@ -60,11 +67,16 @@ export const Basic: Story = {
             <AnonymousForm
               onPrev={() => setStep('모임인원수')}
               onNext={() => setStep('일정입력마감기한')}
+              context={{ state: false, setState: () => {} }}
             />
           </Funnel.Step>
 
           <Funnel.Step name="일정입력마감기한">
-            <DueDateForm onPrev={() => setStep('익명여부')} onNext={() => {}} />
+            <DueDateForm
+              onPrev={() => setStep('익명여부')}
+              onNext={() => {}}
+              context={{ state: '', setState: () => {} }}
+            />
           </Funnel.Step>
         </Funnel>
       </AppLayout>

--- a/src/components/features/CreateMeetingForm/MeetingDateRangeForm.tsx
+++ b/src/components/features/CreateMeetingForm/MeetingDateRangeForm.tsx
@@ -1,19 +1,32 @@
 import { useState } from 'react';
-import { Dayjs } from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
 
 import { Calendar } from '@/components/common/Calendar';
 import { FixedBottomButton } from '@/components/common/FixedBottomButton';
 import { FormLayout } from '@/components/common/FormLayout';
 import { useFunnelProgressContext } from '@/hooks/useFunnelProgressContext';
+import { MeetingForm } from '@/types/meeting';
 
-import { CreateMeetingFormBaseProps } from './types';
+import { CreateMeetingFormBaseProps, FormData } from './types';
 
-type Props = CreateMeetingFormBaseProps;
+type Props<T> = CreateMeetingFormBaseProps & FormData<T>;
 
-export const MeetingDateRangeForm = ({ onNext, onPrev }: Props) => {
+export const MeetingDateRangeForm = ({
+  context,
+  onNext,
+  onPrev,
+}: Props<Pick<MeetingForm, 'meetingStartDate' | 'meetingEndDate'>>) => {
   const { progress, maxProgress } = useFunnelProgressContext();
-  const [selectedStartDate, setSelectedStartDate] = useState<Dayjs | null>(null);
-  const [selectedEndDate, setSelectedEndDate] = useState<Dayjs | null>(null);
+  const { state, setState: setMeetingDateFormData } = context;
+  const { meetingStartDate: meetingStartDateFormData, meetingEndDate: meetingEndDateFormData } =
+    state;
+
+  const [selectedStartDate, setSelectedStartDate] = useState<Dayjs | null>(() =>
+    !!meetingStartDateFormData === true ? dayjs(meetingStartDateFormData) : null
+  );
+  const [selectedEndDate, setSelectedEndDate] = useState<Dayjs | null>(() =>
+    !!meetingEndDateFormData === true ? dayjs(meetingEndDateFormData) : null
+  );
 
   const handleDateChange = (start: Dayjs | null, end: Dayjs | null) => {
     setSelectedStartDate(start);
@@ -35,7 +48,16 @@ export const MeetingDateRangeForm = ({ onNext, onPrev }: Props) => {
         }
       />
       <FixedBottomButton
-        onClick={() => onNext({ start: selectedStartDate, end: selectedEndDate })}
+        onClick={() => {
+          onNext();
+          setMeetingDateFormData({
+            meetingStartDate: dayjs(selectedStartDate).format('YYYY-MM-DD'),
+            meetingEndDate:
+              selectedEndDate === null
+                ? dayjs(selectedStartDate).format('YYYY-MM-DD')
+                : dayjs(selectedEndDate).format('YYYY-MM-DD'),
+          });
+        }}
         disabled={selectedStartDate === null && selectedEndDate === null}
       >
         다음

--- a/src/components/features/CreateMeetingForm/MeetingNameForm.tsx
+++ b/src/components/features/CreateMeetingForm/MeetingNameForm.tsx
@@ -5,17 +5,20 @@ import { FlexBox } from '@/components/common/FlexBox';
 import { FormLayout } from '@/components/common/FormLayout';
 import { TextField } from '@/components/common/TextField';
 import { useFunnelProgressContext } from '@/hooks/useFunnelProgressContext';
+import { MeetingForm } from '@/types/meeting';
 import { createIsInvalidInstance, createIsValidInstance } from '@/utils/validation';
 
-import { CreateMeetingFormBaseProps } from './types';
+import { CreateMeetingFormBaseProps, FormData } from './types';
 
-type Props = CreateMeetingFormBaseProps;
+type Props<T> = CreateMeetingFormBaseProps & FormData<T>;
 
 const MAX_MEETING_NAME_LENGTH = 20;
 
-export const MeetingNameForm = ({ onNext, onPrev }: Props) => {
+export const MeetingNameForm = ({ context, onNext, onPrev }: Props<MeetingForm['meetingName']>) => {
   const { progress, maxProgress } = useFunnelProgressContext();
-  const [meetingName, setMeetingName] = useState('');
+  const { state: meetingNameFormData, setState: setMeetingNameFormData } = context;
+
+  const [meetingName, setMeetingName] = useState(meetingNameFormData);
 
   const isFieldEmpty = meetingName.length === 0;
 
@@ -45,7 +48,10 @@ export const MeetingNameForm = ({ onNext, onPrev }: Props) => {
         }
       />
       <FixedBottomButton
-        onClick={() => onNext(meetingName)}
+        onClick={() => {
+          onNext();
+          setMeetingNameFormData(meetingName);
+        }}
         disabled={isFieldEmpty || validator(meetingName).isValid === false}
       >
         다음

--- a/src/components/features/CreateMeetingForm/MemberCountForm.tsx
+++ b/src/components/features/CreateMeetingForm/MemberCountForm.tsx
@@ -5,14 +5,21 @@ import { FlexBox } from '@/components/common/FlexBox';
 import { FormLayout } from '@/components/common/FormLayout';
 import { Slider } from '@/components/common/Slider';
 import { useFunnelProgressContext } from '@/hooks/useFunnelProgressContext';
+import { MeetingForm } from '@/types/meeting';
 
-import { CreateMeetingFormBaseProps } from './types';
+import { CreateMeetingFormBaseProps, FormData } from './types';
 
-type Props = CreateMeetingFormBaseProps;
+type Props<T> = CreateMeetingFormBaseProps & FormData<T>;
 
-export const MemberCountForm = ({ onNext, onPrev }: Props) => {
+export const MemberCountForm = ({
+  context,
+  onNext,
+  onPrev,
+}: Props<MeetingForm['numberOfPeople']>) => {
   const { progress, maxProgress } = useFunnelProgressContext();
-  const [memberCount, setMemberCount] = useState(2);
+  const { state: memberCountFormData, setState: setMemberCountFormData } = context;
+
+  const [memberCount, setMemberCount] = useState(memberCountFormData);
 
   return (
     <>
@@ -32,7 +39,14 @@ export const MemberCountForm = ({ onNext, onPrev }: Props) => {
           </FlexBox>
         }
       />
-      <FixedBottomButton onClick={() => onNext(memberCount)}>다음</FixedBottomButton>
+      <FixedBottomButton
+        onClick={() => {
+          onNext();
+          setMemberCountFormData(memberCount);
+        }}
+      >
+        다음
+      </FixedBottomButton>
     </>
   );
 };

--- a/src/components/features/CreateMeetingForm/types.ts
+++ b/src/components/features/CreateMeetingForm/types.ts
@@ -1,4 +1,8 @@
 export type CreateMeetingFormBaseProps = {
-  onNext: (data?: unknown) => void;
+  onNext: () => void;
   onPrev: () => void;
+};
+
+export type FormData<T> = {
+  context: { state: T; setState: (newState: T) => void };
 };

--- a/src/constants/meetingForm.ts
+++ b/src/constants/meetingForm.ts
@@ -17,3 +17,14 @@ export const categories = [
   '봉사',
   '기타',
 ] as const;
+
+export const categoryIdMap: Record<(typeof categories)[number], number> = {
+  학교: 1,
+  친구: 2,
+  팀플: 3,
+  회의: 4,
+  스터디: 5,
+  취미: 6,
+  봉사: 7,
+  기타: 8,
+} as const;

--- a/src/hooks/useFunnel.tsx
+++ b/src/hooks/useFunnel.tsx
@@ -1,6 +1,5 @@
-import { ReactElement, useState } from 'react';
+import { ReactElement, useCallback, useState } from 'react';
 
-import { FlexBox } from '@/components/common/FlexBox';
 import { FunnelProgressContext } from '@/contexts/FunnelProgressContext';
 
 type StepNames<T> = readonly T[];
@@ -12,24 +11,27 @@ type StepProps<T> = {
 export const useFunnel = <T,>(stepNames: StepNames<T>) => {
   const [step, setStep] = useState(stepNames[0]);
 
-  const Funnel = ({ children }: { children: ReactElement[] }) => {
-    const stepComponentIndex = children.findIndex((child) => child.props.name === step);
-    const StepComponent = children[stepComponentIndex];
+  const FunnelComponent = useCallback(
+    ({ children }: { children: ReactElement[] }) => {
+      const stepComponentIndex = children.findIndex((child) => child.props.name === step);
+      const StepComponent = children[stepComponentIndex];
 
-    return (
-      <FunnelProgressContext.Provider
-        value={{ progress: stepComponentIndex + 1, maxProgress: children.length }}
-      >
-        {StepComponent}
-      </FunnelProgressContext.Provider>
-    );
-  };
+      return (
+        <FunnelProgressContext.Provider
+          value={{ progress: stepComponentIndex + 1, maxProgress: children.length }}
+        >
+          {StepComponent}
+        </FunnelProgressContext.Provider>
+      );
+    },
+    [step]
+  );
 
-  const Step = ({ children }: StepProps<T>) => {
-    return <FlexBox>{children}</FlexBox>;
-  };
+  const Step = useCallback(({ children }: StepProps<T>) => {
+    return <>{children}</>;
+  }, []);
 
-  Funnel.Step = Step;
+  const Funnel = Object.assign(FunnelComponent, { Step });
 
   return { Funnel, setStep };
 };

--- a/src/hooks/useMeetingFormState.tsx
+++ b/src/hooks/useMeetingFormState.tsx
@@ -1,0 +1,60 @@
+import { useReducer } from 'react';
+
+import { MeetingForm } from '@/types/meeting';
+
+type Action =
+  | 'categoryIds'
+  | 'meetingName'
+  | 'meetingDate'
+  | 'numberOfPeople'
+  | 'isAnonymous'
+  | 'dueDateTime';
+
+export const useMeetingFormState = () => {
+  const [formData, dispatch] = useReducer(reducer, createInitialFormState());
+
+  return [formData, dispatch] as const;
+};
+
+const createInitialFormState = (): MeetingForm => ({
+  categoryIds: [],
+  meetingName: '',
+  meetingStartDate: '',
+  meetingEndDate: '',
+  numberOfPeople: 2,
+  isAnonymous: false,
+  dueDateTime: '',
+});
+
+const reducer = (
+  state: MeetingForm,
+  action: { type: Action; payload: MeetingForm }
+): MeetingForm => {
+  switch (action.type) {
+    case 'categoryIds': {
+      return { ...state, categoryIds: action.payload.categoryIds };
+    }
+    case 'meetingName': {
+      return { ...state, meetingName: action.payload.meetingName };
+    }
+    case 'meetingDate': {
+      return {
+        ...state,
+        meetingStartDate: action.payload.meetingStartDate,
+        meetingEndDate: action.payload.meetingEndDate,
+      };
+    }
+    case 'numberOfPeople': {
+      return { ...state, numberOfPeople: action.payload.numberOfPeople };
+    }
+    case 'isAnonymous': {
+      return { ...state, isAnonymous: action.payload.isAnonymous };
+    }
+    case 'dueDateTime': {
+      return { ...state, dueDateTime: action.payload.dueDateTime };
+    }
+    default: {
+      return state;
+    }
+  }
+};

--- a/src/pages/NewMeeting.tsx
+++ b/src/pages/NewMeeting.tsx
@@ -8,14 +8,22 @@ import {
 } from '@/components/features/CreateMeetingForm';
 import { meetingStepNames } from '@/constants/meetingForm';
 import { useFunnel } from '@/hooks/useFunnel';
+import { useMeetingFormState } from '@/hooks/useMeetingFormState';
 
 export const NewMeeting = () => {
   const { Funnel, setStep } = useFunnel(meetingStepNames);
+  const [formData, dispatch] = useMeetingFormState();
 
   return (
     <Funnel>
       <Funnel.Step name="카테고리">
         <CategoryForm
+          context={{
+            state: formData.categoryIds,
+            setState: (categoryIds) => {
+              dispatch({ type: 'categoryIds', payload: { ...formData, categoryIds } });
+            },
+          }}
           onPrev={() => {
             /* TODO navigate */
           }}
@@ -25,6 +33,12 @@ export const NewMeeting = () => {
 
       <Funnel.Step name="모임이름">
         <MeetingNameForm
+          context={{
+            state: formData.meetingName,
+            setState: (meetingName) => {
+              dispatch({ type: 'meetingName', payload: { ...formData, meetingName } });
+            },
+          }}
           onPrev={() => setStep('카테고리')}
           onNext={() => setStep('일정수집기한')}
         />
@@ -32,6 +46,15 @@ export const NewMeeting = () => {
 
       <Funnel.Step name="일정수집기한">
         <MeetingDateRangeForm
+          context={{
+            state: {
+              meetingStartDate: formData.meetingStartDate,
+              meetingEndDate: formData.meetingEndDate,
+            },
+            setState: (meetingDates) => {
+              dispatch({ type: 'meetingDate', payload: { ...formData, ...meetingDates } });
+            },
+          }}
           onPrev={() => setStep('모임이름')}
           onNext={() => setStep('모임인원수')}
         />
@@ -39,6 +62,11 @@ export const NewMeeting = () => {
 
       <Funnel.Step name="모임인원수">
         <MemberCountForm
+          context={{
+            state: formData.numberOfPeople,
+            setState: (numberOfPeople) =>
+              dispatch({ type: 'numberOfPeople', payload: { ...formData, numberOfPeople } }),
+          }}
           onPrev={() => setStep('일정수집기한')}
           onNext={() => setStep('익명여부')}
         />
@@ -46,6 +74,11 @@ export const NewMeeting = () => {
 
       <Funnel.Step name="익명여부">
         <AnonymousForm
+          context={{
+            state: formData.isAnonymous,
+            setState: (isAnonymous) =>
+              dispatch({ type: 'isAnonymous', payload: { ...formData, isAnonymous } }),
+          }}
           onPrev={() => setStep('모임인원수')}
           onNext={() => setStep('일정입력마감기한')}
         />
@@ -53,6 +86,14 @@ export const NewMeeting = () => {
 
       <Funnel.Step name="일정입력마감기한">
         <DueDateForm
+          context={{
+            state: formData.dueDateTime,
+            setState: (dueDateTime) =>
+              dispatch({
+                type: 'dueDateTime',
+                payload: { ...formData, dueDateTime },
+              }),
+          }}
           onPrev={() => setStep('익명여부')}
           onNext={() => {
             /* TODO navigate */

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -1,0 +1,20 @@
+/**
+ * @example {
+    "categoryIds" : [ 1, 3 ],
+    "meetingName" : "세븐일레븐짱",
+    "meetingStartDate" : "2024-08-27",
+    "meetingEndDate" : "2024-08-29",
+    "numberOfPeople" : 6,
+    "isAnonymous" : false,
+    "voteEndDate" : "2024-08-26T23:59:59"
+  }
+ */
+export type MeetingForm = {
+  categoryIds: number[];
+  meetingName: string;
+  meetingStartDate: string;
+  meetingEndDate: string;
+  numberOfPeople: number;
+  isAnonymous: boolean;
+  dueDateTime: string;
+};


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #104 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

폼 입력 완료하면 마지막에 부모(NewMeeting.tsx)가 갖게되는 formData의 모습 👇
<img width="886" alt="스크린샷 2024-08-26 오전 12 14 50" src="https://github.com/user-attachments/assets/80fda032-b7f2-44c8-b6ec-ab3bdda784ef">

- 각 퍼널 폼 내부에서 관리하는 지역 상태를 부모에서 관리하는 FormData 상태에 통합합니다.
  - 부모 단에서 모든 입력 상태들을 알고 부모가 api 요청을 보내기 위함

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

- #102 -> #108 -> #106 순으로 머지 후 해당 PR 머지해야 합니다. (머지됐다는 가정 하에 작업했습니다)
