### PR TITLE
[CHORE] /src/components에 변경사항이 생긴 경우에만 스토리북 배포

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -1,0 +1,16 @@
+name: check_pull_request
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: ['main']
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: yarn
+      - run: yarn run lint
+        working-directory: .

--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -1,4 +1,4 @@
-name: check_pull_request
+name: Check Pull Request
 
 on:
   pull_request:

--- a/.github/workflows/deploy-storybook.yaml
+++ b/.github/workflows/deploy-storybook.yaml
@@ -1,0 +1,31 @@
+name: deploy-storybook
+
+on:
+  pull_request:
+    types:
+      - closed
+    paths:
+      - 'components/**'
+
+jobs:
+  deploy-storybook:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: install packages
+        run: yarn
+
+      - name: deploy with chromatic
+        id: chromatic
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: storybook deploy alert webhook
+        uses: tsickert/discord-webhook@v5.3.0
+        with:
+          webhook-url: ${{ secrets.WEBHOOK_URL }}
+          content: '✅ PR " ${{ github.event.pull_request.title}} " 의 변경 사항이 Storybook에 배포되었어요! 👉🏻 ${{ steps.chromatic.outputs.storybookUrl }}'

--- a/.github/workflows/deploy-storybook.yaml
+++ b/.github/workflows/deploy-storybook.yaml
@@ -5,11 +5,11 @@ on:
     types:
       - closed
     paths:
-      - 'components/**'
+      - 'src/components/**'
 
 jobs:
   deploy-storybook:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,24 +35,3 @@ jobs:
       - name: Upload to S3
         run: |
           aws s3 cp --recursive --region ap-northeast-2 dist s3://${{ secrets.AWS_BUCKET_NAME}}
-
-  storybookpreview:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-
-      - name: install packages
-        run: yarn
-
-      - name: deploy with chromatic
-        id: chromatic
-        uses: chromaui/action@v1
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: storybook deploy alert webhook
-        uses: tsickert/discord-webhook@v5.3.0
-        with:
-          webhook-url: ${{ secrets.WEBHOOK_URL }}
-          content: '✅ 컴포넌트가 Storybook에 배포되었어요. 확인해 주세요! 👉🏻 ${{ steps.chromatic.outputs.storybookUrl }}'

--- a/.github/workflows/prepublish-storybook.yaml
+++ b/.github/workflows/prepublish-storybook.yaml
@@ -3,7 +3,7 @@ name: prepublish-storybook
 on:
   pull_request:
     paths:
-      - 'components/**'
+      - 'src/components/**'
     types: [opened, reopened, synchronize]
     branches: ['main']
   workflow_dispatch:

--- a/.github/workflows/prepublish-storybook.yaml
+++ b/.github/workflows/prepublish-storybook.yaml
@@ -1,4 +1,4 @@
-name: prepublish-storybook
+name: Prepublish Storybook
 
 on:
   pull_request:

--- a/.github/workflows/prepublish-storybook.yaml
+++ b/.github/workflows/prepublish-storybook.yaml
@@ -1,20 +1,14 @@
-name: check_pull_request
+name: prepublish-storybook
 
 on:
   pull_request:
+    paths:
+      - 'components/**'
     types: [opened, reopened, synchronize]
     branches: ['main']
   workflow_dispatch:
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - run: yarn
-      - run: yarn run lint
-        working-directory: .
-
   storybookpreview:
     runs-on: ubuntu-latest
     steps:
@@ -33,4 +27,4 @@ jobs:
       - name: comment PR
         uses: thollander/actions-comment-pull-request@v2
         with:
-          message: '🎉 Storybook 미리보기: ${{ steps.chromatic.outputs.storybookUrl }}'
+          message: '👀 코드리뷰 전! Storybook 미리보기: ${{ steps.chromatic.outputs.storybookUrl }}'

--- a/.github/workflows/prepublish-storybook.yaml
+++ b/.github/workflows/prepublish-storybook.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  storybookpreview:
+  prepublish-storybook:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #88 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

### PR의 배경 (현재 스토리북 배포의 문제점)

- PR이 작성된 경우와 Main에 머지가 된 경우에 스토리북 배포 액션을 돌리도록 설정하여 컴포넌트에 수정사항이 없음에도 스토리북 배포가 진행됩니다.
  - 불필요한 스토리북 배포 + 알람 발생
    <img width="823" alt="스크린샷 2024-08-28 오전 12 33 52" src="https://github.com/user-attachments/assets/79a73a2a-c228-4697-9d58-8f0d73f49fbe">

- 구현한 컴포넌트를 디자이너에게 QA 받기 위하여 웹훅 설정을 했는데, 해당 알림에서 어떤 변경사항이 발생하여 수정되었는지 확인할 수 없는 번거로움이 존재합니다. (어떤 이유로 배포가 발생했는지 일일이 변경사항을 알려주기도 했음)
  <img width="709" alt="스크린샷 2024-08-28 오전 12 33 10" src="https://github.com/user-attachments/assets/7fbc0aec-e89a-403e-9c14-881a6332f00e">
  <img width="841" alt="스크린샷 2024-08-28 오전 12 35 38" src="https://github.com/user-attachments/assets/e9fdbfa2-a1c3-489e-96f3-a7c065688e7f">

### 수정 사항

- src/components 폴더에 변경사항이 생긴 경우에만 스토리북 배포를 진행합니다.
- src/components 폴더에 변경사항이 있는 PR이 main 브랜치에 머지된 경우 스토리북 알람(디스코드 웹훅)을 전송합니다.
  - 이때 PR의 제목을 알람에 포함시켜 어떤 변경사항이 발생했는지 파악할 수 있도록 합니다.

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

- src/components에 변경사항이 있는 경우에는 모두 액션이 실행되기 때문에, 스토리북을 사용하지 않는 컴포넌트를 변경해도 해당 액션이 실행됩니다.
  - `스토리북 코드에 변경사항이 생긴 경우`로 한정하지 않은 이유는, 구현체나 디자인이 변경되어도 스토리북을 통해 확인할 수 있어야 한다고 판단했기 때문입니다.
