### PR TITLE
[FEAT] Icon 추가

### DIFF
--- a/src/assets/icons/index.tsx
+++ b/src/assets/icons/index.tsx
@@ -37,6 +37,7 @@ import Left from './left.svg?react';
 import Link from './link.svg?react';
 import Next from './next.svg?react';
 import Plus from './plus.svg?react';
+import Prev from './prev.svg?react';
 import Right from './right.svg?react';
 import User from './user.svg?react';
 
@@ -55,6 +56,7 @@ export const IconMap = {
   circle2: Circle2,
   close: Close,
   next: Next,
+  prev: Prev,
   plus: Plus,
   /* 째깍이 */
   jjakkak1: Jjakkak1,

--- a/src/assets/icons/index.tsx
+++ b/src/assets/icons/index.tsx
@@ -35,6 +35,8 @@ import Kakaotalk1 from './kakaotalk-1.svg?react';
 import Kakaotalk2 from './kakaotalk-2.svg?react';
 import Left from './left.svg?react';
 import Link from './link.svg?react';
+import Next from './next.svg?react';
+import Plus from './plus.svg?react';
 import Right from './right.svg?react';
 import User from './user.svg?react';
 
@@ -52,6 +54,8 @@ export const IconMap = {
   circle1: Circle1,
   circle2: Circle2,
   close: Close,
+  next: Next,
+  plus: Plus,
   /* 째깍이 */
   jjakkak1: Jjakkak1,
   jjakkak2: Jjakkak2,

--- a/src/assets/icons/next.svg
+++ b/src/assets/icons/next.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="12" fill="#F6F6F6"/>
+<path d="M10.5 16.5L15 12L10.5 7.5" stroke="#191919" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/plus.svg
+++ b/src/assets/icons/plus.svg
@@ -1,0 +1,18 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_1744_10940)">
+<circle cx="14" cy="14" r="12" fill="white"/>
+</g>
+<path d="M19.0282 14.014H14.0142H9.00013M14.0142 9V19.0281" stroke="#191919" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<defs>
+<filter id="filter0_d_1744_10940" x="0" y="0" width="28" height="28" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.522585 0 0 0 0 0.481071 0 0 0 0 1 0 0 0 0.4 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1744_10940"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1744_10940" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/assets/icons/prev.svg
+++ b/src/assets/icons/prev.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="12" transform="matrix(-1 0 0 1 24 0)" fill="#F6F6F6"/>
+<path d="M13.5 16.5L9 12L13.5 7.5" stroke="#191919" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/common/Icon/Icon.stories.tsx
+++ b/src/components/common/Icon/Icon.stories.tsx
@@ -18,7 +18,7 @@ type Story = StoryObj<typeof Icon>;
 
 export const Basic: Story = {
   args: {
-    color: 'BK',
+    color: 'purple',
     size: 20,
   },
   argTypes: {

--- a/src/components/common/Icon/Icon.types.ts
+++ b/src/components/common/Icon/Icon.types.ts
@@ -4,7 +4,7 @@ import { Colors } from '@/styles/global';
 export type Props = {
   name: IconName;
   /**
-   * @default 'BK'
+   * @default 'purple'
    */
   color?: Colors;
   /**

--- a/src/components/common/Icon/index.tsx
+++ b/src/components/common/Icon/index.tsx
@@ -3,7 +3,7 @@ import { colors } from '@/styles/global';
 
 import { Props } from './Icon.types';
 
-export const Icon = ({ name, color = 'BK', size = 20, ...props }: Props) => {
+export const Icon = ({ name, color = 'purple', size = 20, ...props }: Props) => {
   const IconSVGComponent = IconMap[name];
   const width = typeof size === 'number' ? size : size.width;
   const height = typeof size === 'number' ? size : size.height;


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #123 

## ✨ 작업 내용

- scheduleInput에 사용할 next, plus Icon 추가했습니다.
- svg에 currentColor를 추가한 이후로 default color가 블랙이면 다음과 같이 보이는 현상이 존재했습니다. 따라서 storybook에서 디폴트 컬러 purple로 변경했습니다!

**변경 전**
<img width="541" alt="image" src="https://github.com/user-attachments/assets/c65c35ac-7d00-4c32-a014-c80adc76b289">


**변경 후**
<img width="541" alt="image" src="https://github.com/user-attachments/assets/4fe0eb02-644e-43a6-97ac-759b1b9a1aa1">

## 🙏 기타 참고 사항

- prev 아이콘 까지 추가된 이후에 draft 풀겠습니다!
