### PR TITLE
[FEAT] 말풍선 컴포넌트, 스토리북

### DIFF
--- a/src/components/common/SpeechBubble/SpeechBubble.stories.tsx
+++ b/src/components/common/SpeechBubble/SpeechBubble.stories.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable no-restricted-exports */
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { SpeechBubble } from '.';
+
+const meta = {
+  title: 'components/common/SpeechBubble',
+  component: SpeechBubble,
+  tags: ['autodocs'],
+  parameters: {
+    backgrounds: {
+      default: 'gray',
+      values: [{ name: 'gray', value: '#999' }], // NOTE: 말풍선이 잘 보이도록 배경색을 어둡게 설정
+    },
+  },
+} satisfies Meta<typeof SpeechBubble>;
+
+export default meta;
+type Story = StoryObj<typeof SpeechBubble>;
+
+export const Basic: Story = {
+  args: { children: '째깍! 완벽한 시간이 도착했습니다!' },
+  argTypes: { children: { control: { type: 'text' } } },
+  render: ({ children }) => <SpeechBubble>{children}</SpeechBubble>,
+};
+
+export const LongText: Story = {
+  render: () => (
+    <SpeechBubble>
+      엄청나게 긴 문장이 말풍선 안에 들어갈 때에는 이렇게 보입니다. 엄청나게 긴 문장이 말풍선 안에
+      들어갈 때에는 이렇게 보입니다. 엄청나게 긴 문장이 말풍선 안에 들어갈 때에는 이렇게 보입니다.
+      엄청나게 긴 문장이 말풍선 안에 들어갈 때에는 이렇게 보입니다. 엄청나게 긴 문장이 말풍선 안에
+      들어갈 때에는 이렇게 보입니다. 엄청나게 긴 문장이 말풍선 안에 들어갈 때에는 이렇게 보입니다.
+      엄청나게 긴 문장이 말풍선 안에 들어갈 때에는 이렇게 보입니다. 엄청나게 긴 문장이 말풍선 안에
+      들어갈 때에는 이렇게 보입니다.
+    </SpeechBubble>
+  ),
+};

--- a/src/components/common/SpeechBubble/SpeechBubble.styled.ts
+++ b/src/components/common/SpeechBubble/SpeechBubble.styled.ts
@@ -1,0 +1,19 @@
+import styled from '@emotion/styled';
+
+import { colors } from '@/styles/global';
+
+export const StyledSpeechBubble = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: ${colors.WH};
+  border-radius: 8px;
+  padding: 5px;
+
+  & > svg {
+    position: absolute;
+    right: 1.5px;
+    bottom: -8px;
+  }
+`;

--- a/src/components/common/SpeechBubble/SpeechBubble.types.ts
+++ b/src/components/common/SpeechBubble/SpeechBubble.types.ts
@@ -1,0 +1,3 @@
+export type Props = {
+  children: string;
+};

--- a/src/components/common/SpeechBubble/index.tsx
+++ b/src/components/common/SpeechBubble/index.tsx
@@ -1,0 +1,18 @@
+import { Caption } from '@/components/common/Typography';
+
+import { StyledSpeechBubble } from './SpeechBubble.styled';
+import { Props } from './SpeechBubble.types';
+
+export const SpeechBubble = ({ children }: Props) => {
+  return (
+    <StyledSpeechBubble>
+      <svg width="9" height="16" viewBox="0 0 9 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path
+          d="M0.633711 7.44587C0.26996 7.86589 0.26996 8.48934 0.633711 8.90936L6.4205 15.5914C7.09802 16.3737 8.38321 15.8945 8.38321 14.8596L8.38321 1.4956C8.38321 0.460682 7.09802 -0.0184662 6.4205 0.763859L0.633711 7.44587Z"
+          fill="#FEFEFE"
+        />
+      </svg>
+      <Caption>{children}</Caption>
+    </StyledSpeechBubble>
+  );
+};


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #118 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

- 말풍선 컴포넌트와 스토리북을 추가합니다.
- 사용 예시
  ```tsx
  <SpeechBubble>말풍선에 표시할 텍스트</SpeechBuuble>
  ```
- 렌더
  <img width="293" alt="스크린샷 2024-09-12 오전 12 49 45" src="https://github.com/user-attachments/assets/75448fdb-a67e-4aad-af48-f43eeff55cdb">

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

- 말풍선의 커스텀 여부에 대해서는 고려하지 않았습니다. (e.g. 꼬리의 유무/위치, 말풍선 컬러 등)
