### PR TITLE
[REFACTOR] PinInput 모바일 UI 개선

### DIFF
--- a/src/components/common/PinInput/PinInput.styled.tsx
+++ b/src/components/common/PinInput/PinInput.styled.tsx
@@ -27,8 +27,11 @@ export const StyledCharInput = styled.input`
   font-weight: 500;
   border: none;
   border-bottom: 2px solid ${colors.GY5};
+  border-radius: 0;
   color: ${colors.BK};
   background-color: ${colors.GY6};
+  -webkit-appearance: none;
+  appearance: none;
 
   &:focus {
     outline: none;

--- a/src/components/common/PinInput/PinInput.styled.tsx
+++ b/src/components/common/PinInput/PinInput.styled.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import { colors } from '@/styles/global';
+
 import { Caption } from '../Typography/index';
 
 export const StyledInputContainer = styled.div`
@@ -20,6 +21,7 @@ export const StyledCharContainer = styled.div`
 
 export const StyledCharInput = styled.input`
   width: 30px;
+  height: 100%;
   text-align: center;
   font-size: 24px;
   font-weight: 500;

--- a/src/components/common/PinInput/PinInput.styled.tsx
+++ b/src/components/common/PinInput/PinInput.styled.tsx
@@ -1,14 +1,21 @@
 import styled from '@emotion/styled';
 
 import { colors } from '@/styles/global';
+import { Caption } from '../Typography/index';
 
 export const StyledInputContainer = styled.div`
   width: 100%;
   max-width: 262px;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: flex-start;
+`;
+
+export const StyledCharContainer = styled.div`
+  width: 100%;
+  justify-content: space-between;
+  display: flex;
   align-items: center;
-  gap: 16px;
 `;
 
 export const StyledCharInput = styled.input`
@@ -22,7 +29,11 @@ export const StyledCharInput = styled.input`
   background-color: ${colors.GY6};
 
   &:focus {
-    background-color: ${colors.GY6};
     outline: none;
+    background-color: ${colors.GY6};
   }
+`;
+
+export const StyledHelperText = styled(Caption)`
+  margin-top: 8px;
 `;

--- a/src/components/common/PinInput/index.tsx
+++ b/src/components/common/PinInput/index.tsx
@@ -2,27 +2,42 @@ import { forwardRef } from 'react';
 
 import { PIN } from '@/constants/pin';
 
-import { StyledCharInput, StyledInputContainer } from './PinInput.styled';
+import {
+  StyledCharInput,
+  StyledInputContainer,
+  StyledCharContainer,
+  StyledHelperText,
+} from './PinInput.styled';
 import { Props } from './PinInput.types';
 
 import { usePinInput } from '../../../hooks/usePinInput';
+import { Caption } from '../Typography/index';
 
 export const PinInput = forwardRef<HTMLInputElement, Props>(({ value, onPinChange, ...props }) => {
-  const { inputRefs, handleChange, handleKeyDown } = usePinInput({ value, onPinChange });
+  const { isValid, inputRefs, handleChange, handleKeyDown } = usePinInput({ value, onPinChange });
   return (
     <StyledInputContainer>
-      {Array.from({ length: PIN.LENGTH }).map((_, index) => (
-        <StyledCharInput
-          key={index}
-          ref={(el) => (inputRefs.current[index] = el)}
-          type="text"
-          maxLength={1}
-          value={value[index] || ''}
-          onChange={(e) => handleChange(e, index)}
-          onKeyDown={(e) => handleKeyDown(e, index)}
-          {...props}
-        />
-      ))}
+      <StyledCharContainer>
+        {Array.from({ length: PIN.LENGTH }).map((_, index) => (
+          <StyledCharInput
+            key={index}
+            ref={(el) => (inputRefs.current[index] = el)}
+            type="text"
+            maxLength={1}
+            value={value[index] || ''}
+            onChange={(e) => handleChange(e, index)}
+            onKeyDown={(e) => handleKeyDown(e, index)}
+            {...props}
+          />
+        ))}
+      </StyledCharContainer>
+      <StyledHelperText>
+        {isValid === false && (
+          <Caption color="RD" regularWeight>
+            영문 혹은 숫자만 입력 가능합니다.
+          </Caption>
+        )}
+      </StyledHelperText>
     </StyledInputContainer>
   );
 });

--- a/src/hooks/usePinInput.tsx
+++ b/src/hooks/usePinInput.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useRef } from 'react';
+import { ChangeEvent, useRef, useState } from 'react';
 
 import { PIN } from '@/constants/pin';
 import { englishAndNumberRegex } from '@/utils/regex';
@@ -7,6 +7,7 @@ import { Props } from '../components/common/PinInput/PinInput.types';
 
 export const usePinInput = ({ value, onPinChange }: Props) => {
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+  const [isValid, setIsValid] = useState(true);
 
   const focusInput = (index: number) => {
     if (index >= 0 && index < PIN.LENGTH) {
@@ -17,8 +18,11 @@ export const usePinInput = ({ value, onPinChange }: Props) => {
   const handleChange = (e: ChangeEvent<HTMLInputElement>, index: number) => {
     const newChar = e.target.value.slice(-1);
 
-    if (!englishAndNumberRegex(newChar)) return;
-
+    if (newChar && !englishAndNumberRegex(newChar)) {
+      setIsValid(false);
+      return;
+    }
+    setIsValid(true);
     const newPinValue = [...value];
     newPinValue[index] = newChar;
 
@@ -46,5 +50,5 @@ export const usePinInput = ({ value, onPinChange }: Props) => {
     }
   };
 
-  return { inputRefs, focusInput, handleChange, handleKeyDown };
+  return { isValid, inputRefs, focusInput, handleChange, handleKeyDown };
 };


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #134 

## ✨ 작업 내용

- PinInput 모바일 개선 작업했습니다.
- 한글이나 특수문자가 들어올 경우 Helper 메세지 띄웠습니다!
<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

https://github.com/user-attachments/assets/7124fb88-c8ea-4f48-a603-8bed34443d4c


## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

**문제 원인**

CSS의 캐스케이딩 특징 때문에 개발자가 정의한 스타일이 User Agent Stylesheet을 덮어쓰게 된다고합니당. 따라서 기본적으로 고유한 스타일을 적용시켜서 둥그렇게 보였나봐요.

**해결 방법**

아래 두가지 css 속성은 기본 UI 컨트롤의 외관을 제거해준다고 합니당

```
-webkit-appearance: none;
appearance: none;
```

border는 원래 제가 의도한 대로 `border-bottom`만 남기고, 그 테두리를 직각으로 만들기위해 `border-radius: 0;` 를 추가해줬어요!
