### PR TITLE
[FEAT] 퍼널 스텝에서 마지막(summary) 페이지 제외

### DIFF
--- a/src/components/features/CreateMeetingForm/AnonymousForm.tsx
+++ b/src/components/features/CreateMeetingForm/AnonymousForm.tsx
@@ -4,7 +4,7 @@ import { FixedBottomButton } from '@/components/common/FixedBottomButton';
 import { FlexBox } from '@/components/common/FlexBox';
 import { FormLayout } from '@/components/common/FormLayout';
 import { Switch } from '@/components/common/Switch';
-import { useFunnelProgressContext } from '@/hooks/useFunnelProgressContext';
+import { useMeetingFormProgressContext } from '@/hooks/useMeetingFormProgressContext';
 import { MeetingForm } from '@/types/meeting';
 
 import { CreateMeetingFormBaseProps, FormData } from './types';
@@ -12,7 +12,7 @@ import { CreateMeetingFormBaseProps, FormData } from './types';
 type Props<T> = CreateMeetingFormBaseProps & FormData<T>;
 
 export const AnonymousForm = ({ context, onNext, onPrev }: Props<MeetingForm['isAnonymous']>) => {
-  const { progress, maxProgress } = useFunnelProgressContext();
+  const { progress, maxProgress } = useMeetingFormProgressContext();
   const { state: isAnonymousFormData, setState: setIsAnonymousFormData } = context;
 
   const [isAnonymous, setIsAnonymous] = useState(isAnonymousFormData);

--- a/src/components/features/CreateMeetingForm/CategoryForm.tsx
+++ b/src/components/features/CreateMeetingForm/CategoryForm.tsx
@@ -5,7 +5,7 @@ import { FixedBottomButton } from '@/components/common/FixedBottomButton';
 import { FlexBox } from '@/components/common/FlexBox';
 import { FormLayout } from '@/components/common/FormLayout';
 import { categories, categoryIdMap } from '@/constants/meetingForm';
-import { useFunnelProgressContext } from '@/hooks/useFunnelProgressContext';
+import { useMeetingFormProgressContext } from '@/hooks/useMeetingFormProgressContext';
 import { MeetingForm } from '@/types/meeting';
 
 import { CreateMeetingFormBaseProps, FormData } from './types';
@@ -16,7 +16,7 @@ const MIN_SELECT_COUNT = 1;
 const MAX_SELECT_COUNT = 3;
 
 export const CategoryForm = ({ context, onNext, onPrev }: Props<MeetingForm['categoryIds']>) => {
-  const { progress, maxProgress } = useFunnelProgressContext();
+  const { progress, maxProgress } = useMeetingFormProgressContext();
   const { state: categoryIdsFormData, setState: setCategoryIdsFormData } = context;
 
   const [selectedCategoryIds, setSelectedCategoryIds] = useState<number[]>(categoryIdsFormData);

--- a/src/components/features/CreateMeetingForm/DueDateForm.tsx
+++ b/src/components/features/CreateMeetingForm/DueDateForm.tsx
@@ -5,7 +5,7 @@ import { FixedBottomButton } from '@/components/common/FixedBottomButton';
 import { FlexBox } from '@/components/common/FlexBox';
 import { FormLayout } from '@/components/common/FormLayout';
 import { Switch } from '@/components/common/Switch';
-import { useFunnelProgressContext } from '@/hooks/useFunnelProgressContext';
+import { useMeetingFormProgressContext } from '@/hooks/useMeetingFormProgressContext';
 import { MeetingForm } from '@/types/meeting';
 
 import { CreateMeetingFormBaseProps, FormData } from './types';
@@ -13,7 +13,7 @@ import { CreateMeetingFormBaseProps, FormData } from './types';
 type Props<T> = CreateMeetingFormBaseProps & FormData<T>;
 
 export const DueDateForm = ({ context, onNext, onPrev }: Props<MeetingForm['dueDateTime']>) => {
-  const { progress, maxProgress } = useFunnelProgressContext();
+  const { progress, maxProgress } = useMeetingFormProgressContext();
   const { state: dueDateTime, setState: setDueDateTime } = context;
 
   const [selectedDueDate, setSelectedDueDate] = useState(dueDateTime);

--- a/src/components/features/CreateMeetingForm/MeetingDateRangeForm.tsx
+++ b/src/components/features/CreateMeetingForm/MeetingDateRangeForm.tsx
@@ -4,7 +4,7 @@ import dayjs, { Dayjs } from 'dayjs';
 import { Calendar } from '@/components/common/Calendar';
 import { FixedBottomButton } from '@/components/common/FixedBottomButton';
 import { FormLayout } from '@/components/common/FormLayout';
-import { useFunnelProgressContext } from '@/hooks/useFunnelProgressContext';
+import { useMeetingFormProgressContext } from '@/hooks/useMeetingFormProgressContext';
 import { MeetingForm } from '@/types/meeting';
 
 import { CreateMeetingFormBaseProps, FormData } from './types';
@@ -16,7 +16,7 @@ export const MeetingDateRangeForm = ({
   onNext,
   onPrev,
 }: Props<Pick<MeetingForm, 'meetingStartDate' | 'meetingEndDate'>>) => {
-  const { progress, maxProgress } = useFunnelProgressContext();
+  const { progress, maxProgress } = useMeetingFormProgressContext();
   const { state, setState: setMeetingDateFormData } = context;
   const { meetingStartDate: meetingStartDateFormData, meetingEndDate: meetingEndDateFormData } =
     state;

--- a/src/components/features/CreateMeetingForm/MeetingNameForm.tsx
+++ b/src/components/features/CreateMeetingForm/MeetingNameForm.tsx
@@ -4,7 +4,7 @@ import { FixedBottomButton } from '@/components/common/FixedBottomButton';
 import { FlexBox } from '@/components/common/FlexBox';
 import { FormLayout } from '@/components/common/FormLayout';
 import { TextField } from '@/components/common/TextField';
-import { useFunnelProgressContext } from '@/hooks/useFunnelProgressContext';
+import { useMeetingFormProgressContext } from '@/hooks/useMeetingFormProgressContext';
 import { MeetingForm } from '@/types/meeting';
 import { createIsInvalidInstance, createIsValidInstance } from '@/utils/validation';
 
@@ -15,7 +15,7 @@ type Props<T> = CreateMeetingFormBaseProps & FormData<T>;
 const MAX_MEETING_NAME_LENGTH = 20;
 
 export const MeetingNameForm = ({ context, onNext, onPrev }: Props<MeetingForm['meetingName']>) => {
-  const { progress, maxProgress } = useFunnelProgressContext();
+  const { progress, maxProgress } = useMeetingFormProgressContext();
   const { state: meetingNameFormData, setState: setMeetingNameFormData } = context;
 
   const [meetingName, setMeetingName] = useState(meetingNameFormData);

--- a/src/components/features/CreateMeetingForm/MemberCountForm.tsx
+++ b/src/components/features/CreateMeetingForm/MemberCountForm.tsx
@@ -4,7 +4,7 @@ import { FixedBottomButton } from '@/components/common/FixedBottomButton';
 import { FlexBox } from '@/components/common/FlexBox';
 import { FormLayout } from '@/components/common/FormLayout';
 import { Slider } from '@/components/common/Slider';
-import { useFunnelProgressContext } from '@/hooks/useFunnelProgressContext';
+import { useMeetingFormProgressContext } from '@/hooks/useMeetingFormProgressContext';
 import { MeetingForm } from '@/types/meeting';
 
 import { CreateMeetingFormBaseProps, FormData } from './types';
@@ -16,7 +16,7 @@ export const MemberCountForm = ({
   onNext,
   onPrev,
 }: Props<MeetingForm['numberOfPeople']>) => {
-  const { progress, maxProgress } = useFunnelProgressContext();
+  const { progress, maxProgress } = useMeetingFormProgressContext();
   const { state: memberCountFormData, setState: setMemberCountFormData } = context;
 
   const [memberCount, setMemberCount] = useState(memberCountFormData);

--- a/src/hooks/useMeetingFormProgressContext.tsx
+++ b/src/hooks/useMeetingFormProgressContext.tsx
@@ -1,0 +1,9 @@
+import { useContext } from 'react';
+
+import { FunnelProgressContext } from '@/contexts/FunnelProgressContext';
+
+export const useMeetingFormProgressContext = () => {
+  const { progress, maxProgress } = useContext(FunnelProgressContext);
+
+  return { progress, maxProgress: maxProgress - 1 }; // NOTE: 마지막 Summary 페이지는 스텝에서 제외
+};


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

#105 의 step PR 입니다 (PR 크기가 커질 것 같아서 쪼개서 작성합니다)

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

<img width="363" alt="스크린샷 2024-09-17 오전 12 19 57" src="https://github.com/user-attachments/assets/95c90a19-9aa9-473c-8614-9194811899d3">

- 위 일정 확정 페이지가 추가됨에 따라, 퍼널의 progress가 7로 증가하는 문제를 해결합니다.
- `useMeetingFormProgressContext` 훅을 추가하여 progress가 6으로 유지되도록 합니다.
  - 위 훅은 `useContext(FunnelProgressContext)`를 래핑한 훅입니다.

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
