### PR TITLE
[BUGFIX] useSchedule getSelectedTimeRanges 배열 객체로 변환

### DIFF
--- a/src/hooks/useSchedule.tsx
+++ b/src/hooks/useSchedule.tsx
@@ -91,7 +91,7 @@ export const useSchedule = (
   );
 
   const getSelectedTimeRanges = useCallback(() => {
-    const selectedRanges: string[] = [];
+    const selectedRanges: { startTime: string; endTime: string }[] = [];
 
     Object.entries(timeSlots).forEach(([dateKey, slots]) => {
       let startTime: number | null = null;
@@ -102,14 +102,20 @@ export const useSchedule = (
           startTime = index;
         } else if (!isSelected && startTime !== null) {
           endTime = index;
-          selectedRanges.push(`${dateKey} ${formatTime(startTime)}~${formatTime(endTime)}`);
+          selectedRanges.push({
+            startTime: `${dateKey}T${formatTime(startTime)}`,
+            endTime: `${dateKey}T${formatTime(endTime)}`,
+          });
           startTime = null;
           endTime = null;
         }
       });
 
       if (startTime !== null) {
-        selectedRanges.push(`${dateKey} ${formatTime(startTime)}~${formatTime(slots.length)}`);
+        selectedRanges.push({
+          startTime: `${dateKey}T${formatTime(startTime)}`,
+          endTime: `${dateKey}T${formatTime(slots.length)}`,
+        });
       }
     });
 


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #151 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->
- useSchedule훅에서 배열로 저장되고 있던 timeSlots value를 배열 객체로 변환했습니다. 

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
