### PR TITLE
[FEAT] Header에 backgroundColor 프롭 추가

### DIFF
--- a/src/components/common/Header/Header.types.ts
+++ b/src/components/common/Header/Header.types.ts
@@ -1,5 +1,8 @@
+import { Colors } from '@/styles/global';
+
 export type Props = {
   left: React.ReactNode;
   middle?: React.ReactNode;
   right?: React.ReactNode;
+  backgroundColor?: Colors;
 };

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -1,12 +1,11 @@
 import { css } from '@emotion/react';
 
 import { FlexBox } from '@/components/common/FlexBox';
-import { colors } from '@/styles/global';
 
 import { LeftWrapper, MiddleWrapper, RightWrapper } from './Header.styled';
 import { Props } from './Header.types';
 
-export const Header = ({ left, middle, right }: Props) => {
+export const Header = ({ left, middle, right, backgroundColor = 'GY6' }: Props) => {
   return (
     <FlexBox
       as="header"
@@ -19,7 +18,7 @@ export const Header = ({ left, middle, right }: Props) => {
         position: sticky;
         top: 0;
         z-index: 50;
-        background-color: ${colors.GY6};
+        background-color: ${backgroundColor};
       `}
     >
       <LeftWrapper>{left}</LeftWrapper>


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #167 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

- Header에 backgroundColor 프롭을 추가합니다.
  - 헤더의 배경색이 변경되는 것이 특수한 케이스라 `backgroundColor` 프롭에 대한 스토리는 따로 다루지 않았습니다.

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
