### PR TITLE
[FIX] FixedBottomButton css 수정

### DIFF
--- a/src/components/common/FixedBottomButton/FixedBottomButton.styled.ts
+++ b/src/components/common/FixedBottomButton/FixedBottomButton.styled.ts
@@ -1,14 +1,14 @@
 import styled from '@emotion/styled';
 
 export const Container = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
   width: 100%;
   max-width: 430px;
-  position: absolute;
   padding-left: 20px;
   padding-right: 20px;
   padding-bottom: 82px;
-  margin: auto;
-  bottom: 0;
-  border: none;
-  z-index: 10;
+  z-index: 999;
 `;

--- a/src/components/common/FixedBottomButton/FixedBottomButton.styled.ts
+++ b/src/components/common/FixedBottomButton/FixedBottomButton.styled.ts
@@ -3,8 +3,6 @@ import styled from '@emotion/styled';
 export const Container = styled.div`
   position: fixed;
   bottom: 0;
-  left: 0;
-  right: 0;
   width: 100%;
   max-width: 430px;
   padding-left: 20px;


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #186 

## ✨ 작업 내용
- FixedBottomButton `positon` 값 변경했습니다!
- `sticky` 로 적용하면 버튼이 가운데 뜹니다..🤔 (왜 뜨는거일까욥..) 따라서 `fixed`로 구현했습니다!

<img width="442" alt="스크린샷 2024-09-21 오후 9 16 07" src="https://github.com/user-attachments/assets/ac2a4338-d310-4af4-8538-14c53536aa44">

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
