### PR TITLE
[FEAT] ScheduleLayout Header backgroundColor 지정

### DIFF
--- a/src/components/common/ScheduleLayout/ScheduleLayout.styled.ts
+++ b/src/components/common/ScheduleLayout/ScheduleLayout.styled.ts
@@ -8,7 +8,8 @@ export const StyledScheduleLayoutContainer = styled.div`
   justify-content: flex-start;
   background: linear-gradient(
     180deg,
-    rgba(133, 123, 255, 0.9) 0%,
+    rgba(133, 123, 255) 0%,
+    rgba(133, 123, 255) 10%,
     rgba(133, 123, 255, 0.9) 60%,
     ${colors.GY6} 100%
   );

--- a/src/components/common/ScheduleLayout/index.tsx
+++ b/src/components/common/ScheduleLayout/index.tsx
@@ -22,6 +22,7 @@ export const ScheduleLayout = ({
         <Header
           left={<IconButton iconName="jjakkakText" size={130} iconColor="WH" />}
           right={<IconButton iconName="user" size={28} iconColor="WH" />}
+          backgroundColor="purple"
         />
         <FlexBox width="100%" alignItems="normal" gap={2} padding="10px 20px 0px 20px">
           <Chip.Group type="slide">


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #190 

## ✨ 작업 내용

- ScheduleLayout Header backgroundColor 지정했습니다!
- 그라데이션이 purple에 투명도를 주기 때문에 Header 색상과 자연스럽게 이어지기 위해 다음과 같은 작업해줬습니다!
```
rgba(133, 123, 255) 0%,
rgba(133, 123, 255) 10%,
rgba(133, 123, 255, 0.9) 60%,
```



<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
