### PR TITLE
[FEAT] ScheduleInput/TimeRangePicker totalPeopleNum, meetingTimeList Props 추가

### DIFF
--- a/src/components/common/ScheduleInput/ScheduleInput.type.ts
+++ b/src/components/common/ScheduleInput/ScheduleInput.type.ts
@@ -3,6 +3,24 @@ import { Dayjs } from 'dayjs';
 
 export type Props = {
   /**
+   * The total number of people who have been scheduled for the meeting.
+   * @example 4
+   */
+  totalPeopleNum?: number;
+  /**
+   * A list of meeting times that includes the names of participants and the startTime and endTime for each time slot.
+   * @example
+   * [
+   *   { memberNames: ['John', 'Jane'], startTime: '2024-09-22T09:00', endTime: '2024-09-22T10:00' },
+   *   { memberNames: ['Alice'], startTime: '2024-09-22T10:00', endTime: '2024-09-22T11:00' }
+   * ]
+   */
+  meetingTimeList?: {
+    memberNames: string[];
+    startTime: string;
+    endTime: string;
+  }[];
+  /**
    * The start date of the schedule in string format.
    */
   startDate: string;

--- a/src/components/common/ScheduleInput/index.tsx
+++ b/src/components/common/ScheduleInput/index.tsx
@@ -26,7 +26,18 @@ dayjs.locale('ko');
 
 export const ScheduleInput = forwardRef<HTMLDivElement, Props>(
   (
-    { startDate, endDate, currentDates, timeSlots, moveNext, movePrev, onTimeSlotClick, ...props },
+    {
+      startDate,
+      endDate,
+      currentDates,
+      timeSlots,
+      moveNext,
+      movePrev,
+      onTimeSlotClick,
+      meetingTimeList = [],
+      totalPeopleNum = 0,
+      ...props
+    },
     ref
   ) => {
     const [isDragging, setIsDragging] = useState(false);
@@ -102,6 +113,10 @@ export const ScheduleInput = forwardRef<HTMLDivElement, Props>(
               return (
                 <TimeRangePicker
                   key={date.format('YYYY-MM-DD')}
+                  colIndex={colIndex}
+                  totalPeopleNum={totalPeopleNum}
+                  meetingTimeList={meetingTimeList}
+                  currentDate={date.toDate()}
                   selectedSlots={timeSlots[dateKey] || []}
                   onTimeSlotClick={(rowIndex: number, colIndex: number) =>
                     onTimeSlotClick(rowIndex, colIndex)
@@ -113,7 +128,6 @@ export const ScheduleInput = forwardRef<HTMLDivElement, Props>(
                     handleMove(rowIndex, colIndex + touchedColIndex - colIndex)
                   }
                   onDragEnd={handleEnd}
-                  colIndex={colIndex}
                 />
               );
             })}

--- a/src/components/common/TimeRangePicker/TimeRangePicker.styled.ts
+++ b/src/components/common/TimeRangePicker/TimeRangePicker.styled.ts
@@ -2,6 +2,19 @@ import styled from '@emotion/styled';
 
 import { colors } from '@/styles/global';
 
+const intensityColors = [
+  '#F1EFFF',
+  '#E6E4FF',
+  '#DBD7FF',
+  '#CECAFF',
+  '#BDB8FF',
+  '#A7A0FF',
+  '#978EFF',
+  '#857BFF',
+  '#7468FF',
+  '#654AFF',
+];
+
 export const StyledTimeBoxContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -14,16 +27,26 @@ export const TimeBoxSelector = styled.div<{
   isSelected: boolean;
   isFirst: boolean;
   isLast: boolean;
+  intensity: number;
+  totalPeopleNum: number;
 }>`
   flex: 1;
   height: 35px;
-  background-color: ${(props) => (props.isSelected ? colors.purple : colors.GY6)};
+  background-color: ${(props) => {
+    if (props.isSelected) return colors.purple;
+    if (props.intensity > 0) {
+      const baseIndex = 10 - props.totalPeopleNum;
+      const colorIndex = 10 - baseIndex + props.intensity;
+      return intensityColors[colorIndex];
+    }
+    return colors.GY6;
+  }};
   cursor: pointer;
   touch-action: none;
   border-left: 0.5px solid ${colors.WH};
   border-right: 0.5px solid ${colors.WH};
   border-bottom: 1px ${colors.WH}
-    ${(props) => (props.isLast || props.index === 14 ? 'solid' : 'dashed')};
+    ${(props) => (props.isLast || props.intensity > 0 || props.index === 14 ? 'solid' : 'dashed')};
   border-radius: ${(props) => {
     if (props.isSelected) {
       if (props.isFirst && props.isLast) return '8px';

--- a/src/components/common/TimeRangePicker/TimeRangePicker.type.ts
+++ b/src/components/common/TimeRangePicker/TimeRangePicker.type.ts
@@ -2,6 +2,10 @@ import { ComponentPropsWithoutRef } from 'react';
 
 export type Props = {
   /**
+   *  column index
+   */
+  colIndex: number;
+  /**
    * An array of boolean values representing the selection state of each time slot.
    */
   selectedSlots: boolean[];
@@ -22,7 +26,26 @@ export type Props = {
    */
   onDragEnd?: () => void;
   /**
-   *  column index
+   * The currently selected or displayed date in the time range picker.
+   * @example new Date("2024-09-22")
    */
-  colIndex: number;
+  currentDate?: Date;
+  /**
+   * The total number of people who have been scheduled for the meeting.
+   * @example 4
+   */
+  totalPeopleNum?: number;
+  /**
+   * A list of meeting times that includes the names of participants and the startTime and endTime for each time slot.
+   * @example
+   * [
+   *   { memberNames: ['John', 'Jane'], startTime: '2024-09-22T09:00', endTime: '2024-09-22T10:00' },
+   *   { memberNames: ['Alice'], startTime: '2024-09-22T10:00', endTime: '2024-09-22T11:00' }
+   * ]
+   */
+  meetingTimeList?: {
+    memberNames: string[];
+    startTime: string;
+    endTime: string;
+  }[];
 } & ComponentPropsWithoutRef<'div'>;

--- a/src/components/common/TimeRangePicker/index.tsx
+++ b/src/components/common/TimeRangePicker/index.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, useCallback, useRef, useEffect } from 'react';
+import dayjs from 'dayjs';
 
 import { StyledTimeBoxContainer, TimeBoxSelector } from './TimeRangePicker.styled';
 import { Props } from './TimeRangePicker.type';
@@ -11,6 +12,9 @@ export const TimeRangePicker = forwardRef<HTMLDivElement, Props>(
     onDragEnd = () => {},
     onTimeSlotClick = () => {},
     colIndex,
+    meetingTimeList = [],
+    totalPeopleNum = 0,
+    currentDate,
     ...props
   }) => {
     const containerRef = useRef<HTMLDivElement>(null);
@@ -38,6 +42,17 @@ export const TimeRangePicker = forwardRef<HTMLDivElement, Props>(
       [onDragMove]
     );
 
+    const getIntensityForTimeSlot = (index: number) => {
+      const hour = 9 + index;
+      const currentDateStr = dayjs(currentDate).format('YYYY-MM-DD');
+      const matchingSlots = meetingTimeList?.filter((slot) => {
+        const slotStart = dayjs(slot.startTime);
+        return slotStart.format('YYYY-MM-DD') === currentDateStr && slotStart.hour() === hour;
+      });
+
+      return matchingSlots && matchingSlots.length > 0 ? matchingSlots[0].memberNames.length : 0;
+    };
+
     useEffect(() => {
       const container = containerRef.current;
       if (container) {
@@ -63,6 +78,8 @@ export const TimeRangePicker = forwardRef<HTMLDivElement, Props>(
           const isGroupStart = isSelected && !prevSlot;
           const isGroupEnd = isSelected && !nextSlot;
 
+          const intensity = getIntensityForTimeSlot(index);
+
           return (
             <TimeBoxSelector
               key={index}
@@ -72,6 +89,8 @@ export const TimeRangePicker = forwardRef<HTMLDivElement, Props>(
               isFirst={isGroupStart}
               isLast={isGroupEnd}
               isSelected={isSelected}
+              intensity={intensity}
+              totalPeopleNum={totalPeopleNum}
               onMouseDown={() => onDragStart(index, colIndex)}
               onMouseEnter={() => onDragMove(index, colIndex)}
               onTouchStart={() => onTouchStart(index - 1, colIndex)}


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #213 

## ✨ 작업 내용

- ScheduleInput/TimeRangePicker totalPeopleNum, meetingTimeList Props 추가했습니다!

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
- 일정 한눈에 보기를 진행할 때  모임일정 시간 조회 API의 meetingTimeList.memberNames.length을 활용하여 해당 시간대에 투표한 인원이 몇명인지 보여주는데 사용했습니다. 
- 총인원이 4명이라면 color 색상이 너무 연하기 때문에 totalPeopleNum을 받아 `(10 - totalPeopleNum)` 을 baseColor로 지정하고, `10 - baseIndex + meetingTimeList.memberNames.length(props.intensity)` 값을 더해서 계산했습니당

```
meetingTimeList": [
    {
        "memberNames": [
            "멤버",
            "멤버",
            "dd"
        ],
        "startTime": "2024-09-26T15:00:00",
        "endTime": "2024-09-26T16:00:00",
        "rank": 1.0
    },
    {
        "memberNames": [
            "멤버",
            "멤버",
            "dd"
        ],
        "startTime": "2024-09-26T16:00:00",
        "endTime": "2024-09-26T17:00:00",
        "rank": 1.0
    },
];
```

