### PR TITLE
[FEAT] 일정 한눈에 보기 페이지 API 연결

### DIFF
--- a/src/components/common/TimeRangePicker/TimeRangePicker.styled.ts
+++ b/src/components/common/TimeRangePicker/TimeRangePicker.styled.ts
@@ -37,7 +37,8 @@ export const TimeBoxSelector = styled.div<{
       const baseIndex = 10 - props.totalPeopleNum;
       const colorIndex = 10 - baseIndex + props.intensity;
       return intensityColors[colorIndex];
-    } else if (props.isSelected) return colors.purple;
+    }
+    if (props.isSelected) return colors.purple;
     return colors.GY6;
   }};
   cursor: pointer;

--- a/src/components/common/TimeRangePicker/TimeRangePicker.styled.ts
+++ b/src/components/common/TimeRangePicker/TimeRangePicker.styled.ts
@@ -33,12 +33,11 @@ export const TimeBoxSelector = styled.div<{
   flex: 1;
   height: 35px;
   background-color: ${(props) => {
-    if (props.isSelected) return colors.purple;
     if (props.intensity > 0) {
       const baseIndex = 10 - props.totalPeopleNum;
       const colorIndex = 10 - baseIndex + props.intensity;
       return intensityColors[colorIndex];
-    }
+    } else if (props.isSelected) return colors.purple;
     return colors.GY6;
   }};
   cursor: pointer;
@@ -46,7 +45,7 @@ export const TimeBoxSelector = styled.div<{
   border-left: 0.5px solid ${colors.WH};
   border-right: 0.5px solid ${colors.WH};
   border-bottom: 1px ${colors.WH}
-    ${(props) => (props.isLast || props.intensity > 0 || props.index === 14 ? 'solid' : 'dashed')};
+    ${(props) => (props.isLast || props.index === 14 ? 'solid' : 'dashed')};
   border-radius: ${(props) => {
     if (props.isSelected) {
       if (props.isFirst && props.isLast) return '8px';

--- a/src/components/common/TimeRangePicker/index.tsx
+++ b/src/components/common/TimeRangePicker/index.tsx
@@ -42,15 +42,26 @@ export const TimeRangePicker = forwardRef<HTMLDivElement, Props>(
       [onDragMove]
     );
 
-    const getIntensityForTimeSlot = (index: number) => {
+    const getSlotInfo = (index: number) => {
       const hour = 9 + index;
       const currentDateStr = dayjs(currentDate).format('YYYY-MM-DD');
       const matchingSlots = meetingTimeList?.filter((slot) => {
         const slotStart = dayjs(slot.startTime);
+
         return slotStart.format('YYYY-MM-DD') === currentDateStr && slotStart.hour() === hour;
       });
 
-      return matchingSlots && matchingSlots.length > 0 ? matchingSlots[0].memberNames.length : 0;
+      const intensity =
+        matchingSlots && matchingSlots.length > 0 ? matchingSlots[0].memberNames.length : 0;
+      const isSelected = selectedSlots[index] || intensity > 0;
+
+      return { intensity, isSelected };
+    };
+
+    const isGroupBoundary = (index: number, isStart: boolean) => {
+      const { isSelected } = getSlotInfo(index);
+      const { isSelected: adjacentSelected } = getSlotInfo(isStart ? index - 1 : index + 1);
+      return isSelected && !adjacentSelected;
     };
 
     useEffect(() => {
@@ -71,14 +82,11 @@ export const TimeRangePicker = forwardRef<HTMLDivElement, Props>(
         {...props}
       >
         {Array.from({ length: 15 }).map((_, index) => {
-          const isSelected = selectedSlots[index] || false;
-          const prevSlot = selectedSlots[index - 1] || false;
-          const nextSlot = selectedSlots[index + 1] || false;
+          const { intensity, isSelected } = getSlotInfo(index);
+          const isGroupStart = isGroupBoundary(index, true);
+          const isGroupEnd = isGroupBoundary(index, false);
 
-          const isGroupStart = isSelected && !prevSlot;
-          const isGroupEnd = isSelected && !nextSlot;
-
-          const intensity = getIntensityForTimeSlot(index);
+          console.log('intensity', intensity);
 
           return (
             <TimeBoxSelector

--- a/src/components/features/MeetingDetail/MemberScheduleCard.tsx
+++ b/src/components/features/MeetingDetail/MemberScheduleCard.tsx
@@ -45,7 +45,7 @@ export const MemberScheduleCard = ({ uuid, onNavigate }: MemberScheduleProps) =>
             disabled={scheduleTimeData.meetingTimeList.length === 0}
             onClick={() => {
               if (scheduleTimeData.meetingTimeList.length !== 0) {
-                onNavigate(`/${uuid}/totalTime`);
+                onNavigate(`/${uuid}/schedules`);
               }
             }}
           >

--- a/src/pages/TimeCollection.tsx
+++ b/src/pages/TimeCollection.tsx
@@ -1,4 +1,4 @@
-import { useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQueries } from '@tanstack/react-query';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 
 import { queries } from '@/apis';

--- a/src/pages/TimeCollection.tsx
+++ b/src/pages/TimeCollection.tsx
@@ -1,4 +1,4 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 
 import { queries } from '@/apis';
@@ -15,8 +15,9 @@ export const TimeCollection = () => {
   const { uuid } = useParams();
   const navigate = useNavigate();
 
-  const { data: meetingData } = useSuspenseQuery(queries.meeting.info(uuid as string));
-  const { data: scheduleData } = useSuspenseQuery(queries.meeting.times(uuid as string));
+  const [{ data: meetingData }, { data: scheduleData }] = useSuspenseQueries({
+    queries: [queries.meeting.info(uuid as string), queries.meeting.times(uuid as string)],
+  });
 
   const { currentDates, timeSlots, moveNext, movePrev } = useSchedule(
     meetingData.meetingStartDate,

--- a/src/pages/TimeCollection.tsx
+++ b/src/pages/TimeCollection.tsx
@@ -1,0 +1,65 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
+
+import { queries } from '@/apis';
+import { FixedBottomButton } from '@/components/common/FixedBottomButton';
+import { FlexBox } from '@/components/common/FlexBox';
+import { FormLayout } from '@/components/common/FormLayout';
+import { Header } from '@/components/common/Header';
+import { IconButton } from '@/components/common/IconButton';
+import { ScheduleInput } from '@/components/common/ScheduleInput';
+import { Body2 } from '@/components/common/Typography';
+import { useSchedule } from '@/hooks/useSchedule';
+
+export const TimeCollection = () => {
+  const { uuid } = useParams();
+  const navigate = useNavigate();
+
+  const { data: meetingData } = useSuspenseQuery(queries.meeting.info(uuid as string));
+  const { data: scheduleData } = useSuspenseQuery(queries.meeting.times(uuid as string));
+
+  const { currentDates, timeSlots, moveNext, movePrev } = useSchedule(
+    meetingData.meetingStartDate,
+    meetingData.meetingEndDate
+  );
+
+  if (uuid === undefined) {
+    return <Navigate to="/" />;
+  }
+
+  return (
+    <>
+      <FormLayout
+        header={
+          <Header
+            left={<IconButton iconName="back" onClick={() => navigate(`/${uuid}/totalTime`)} />}
+            middle={<Body2>일정 확인</Body2>}
+          />
+        }
+        title=""
+        content={
+          <FlexBox
+            flexDir="column"
+            width="100%"
+            height="calc(100vh - 200px)"
+            alignItems="start"
+            padding="0 0 60px 0"
+          >
+            <ScheduleInput
+              startDate={meetingData.meetingStartDate}
+              endDate={meetingData.meetingEndDate}
+              currentDates={currentDates}
+              timeSlots={timeSlots}
+              moveNext={moveNext}
+              movePrev={movePrev}
+              onTimeSlotClick={() => {}}
+              totalPeopleNum={scheduleData.numberOfPeople}
+              meetingTimeList={scheduleData.meetingTimeList}
+            />
+          </FlexBox>
+        }
+      />
+      <FixedBottomButton onClick={() => navigate(`/${uuid}`)}>확인</FixedBottomButton>
+    </>
+  );
+};

--- a/src/pages/TimeCollection.tsx
+++ b/src/pages/TimeCollection.tsx
@@ -32,7 +32,7 @@ export const TimeCollection = () => {
       <FormLayout
         header={
           <Header
-            left={<IconButton iconName="back" onClick={() => navigate(`/${uuid}/totalTime`)} />}
+            left={<IconButton iconName="back" onClick={() => navigate(`/${uuid}/schedules`)} />}
             middle={<Body2>일정 확인</Body2>}
           />
         }

--- a/src/routes/route.tsx
+++ b/src/routes/route.tsx
@@ -79,10 +79,10 @@ export const router = createBrowserRouter([
             element: <PinRelease />,
           },
           {
-            path: 'totalTime',
+            path: 'schedules',
             element: <TotalSchedule />,
           },
-          { path: 'result', element: <TimeCollection /> },
+          { path: 'schedules/overview', element: <TimeCollection /> },
         ],
       },
     ],

--- a/src/routes/route.tsx
+++ b/src/routes/route.tsx
@@ -12,6 +12,7 @@ import { NewMeetingShare } from '@/pages/NewMeetingShare';
 import { NewSchedule } from '@/pages/NewSchedule';
 import { Onboarding } from '@/pages/Onboarding';
 import { PinRelease } from '@/pages/PinRelease';
+import { TimeCollection } from '@/pages/TimeCollection';
 import { TotalSchedule } from '@/pages/TotalSchedule';
 
 import { PrivateRoute } from './PrivateRoute';
@@ -81,6 +82,7 @@ export const router = createBrowserRouter([
             path: 'totalTime',
             element: <TotalSchedule />,
           },
+          { path: 'result', element: <TimeCollection /> },
         ],
       },
     ],


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #223 

## ✨ 작업 내용

- 일정 한눈에 보기 페이지 API 연결진행했습니다.
- `totalTime` , `result` 보다 조금 더 직관적인 route 이름이 필요할 것 같습니다! 둘 다 전체 일정의 시간에 관한 데이터들을 보여줘서 고민이됩니당

![Sep-25-2024 04-55-47](https://github.com/user-attachments/assets/5c01cd1b-9fbc-4cf5-991b-4a8a02f11c45)


<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
