### PR TITLE
[FEAT] 일정 수정 API 연결

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -3,19 +3,23 @@ import { meeting as meetingMutations } from './meeting/mutations';
 import { meeting as meetingQueries } from './meeting/queries';
 import { member as memberApis } from './member/api';
 import { member as memberQueries } from './member/queries';
+import { schedule as scheduleApis } from './schedule/api';
 import {
   memberSchedule as memberScheduleMutations,
   nonMemberSchedule as nonMemberScheduleMutations,
 } from './schedule/mutations';
+import { schedule as scheduleQueries } from './schedule/queries';
 
 export const apis = {
   member: memberApis,
   meeting: meetingApis,
+  schedule: scheduleApis,
 };
 
 export const queries = {
   member: memberQueries,
   meeting: meetingQueries,
+  schedule: scheduleQueries,
 };
 
 export const mutations = {

--- a/src/apis/schedule/api.ts
+++ b/src/apis/schedule/api.ts
@@ -1,7 +1,7 @@
 import { instance } from '@/lib/axios';
-import { newSchedule } from '@/types/schedule';
+import { Schedule, newSchedule } from '@/types/schedule';
 
-import { CreateScheduleResponse } from './type';
+import { CreateScheduleResponse, ScheduleTimeResponse } from './type';
 
 export const schedule = {
   /**
@@ -9,6 +9,17 @@ export const schedule = {
    */
   createMemberSchedule: async (data: newSchedule, uuid: string) => {
     const response = await instance.post(`/meetings/${uuid}/schedules/members`, data, {
+      withCredentials: true,
+      headers: { Authorization: localStorage.getItem('accessToken') },
+    });
+
+    return response.data;
+  },
+  /**
+   * @description 회원 일정 수정
+   */
+  editMemberSchedule: async (data: { dateOfScheduleList: Schedule[] }, uuid: string) => {
+    const response = await instance.patch(`/meetings/${uuid}/schedules`, data, {
       withCredentials: true,
       headers: { Authorization: localStorage.getItem('accessToken') },
     });
@@ -24,6 +35,43 @@ export const schedule = {
       data
     );
 
+    return response.data;
+  },
+  /**
+   * @description 비회원 일정 수정
+   */
+  editNonMemberSchedule: async (
+    data: { dateOfScheduleList: Schedule[] },
+    scheduleUuid: string,
+    nonMemberUuid: string
+  ) => {
+    const response = await instance.patch(
+      `/meetings/${scheduleUuid}/schedules/${nonMemberUuid}`,
+      data
+    );
+
+    return response.data;
+  },
+  /**
+   * @description 회원 일정 조회
+   */
+  member: async (scheduleUuid: string) => {
+    const response = await instance.get<ScheduleTimeResponse>(
+      `/meetings/${scheduleUuid}/schedules/members`,
+      {
+        withCredentials: true,
+        headers: { Authorization: localStorage.getItem('accessToken') },
+      }
+    );
+    return response.data;
+  },
+  /**
+   * @description 비회원 일정 조회
+   */
+  guests: async (scheduleUuid: string, nonMemberUuid: string) => {
+    const response = await instance.get<ScheduleTimeResponse>(
+      `/meetings/${scheduleUuid}/schedules/guests?scheduleUuid=${nonMemberUuid}`
+    );
     return response.data;
   },
 };

--- a/src/apis/schedule/mutations.ts
+++ b/src/apis/schedule/mutations.ts
@@ -4,10 +4,16 @@ export const memberSchedule = {
   createMemberSchedule: {
     mutationFn: scheduleApi.createMemberSchedule,
   },
+  editMemberSchedule: {
+    mutationFn: scheduleApi.editMemberSchedule,
+  },
 } as const;
 
 export const nonMemberSchedule = {
   createNonMemberSchedule: {
     mutationFn: scheduleApi.createNonMemberSchedule,
+  },
+  editNonMemberSchedule: {
+    mutationFn: scheduleApi.editNonMemberSchedule,
   },
 } as const;

--- a/src/apis/schedule/queries.ts
+++ b/src/apis/schedule/queries.ts
@@ -1,0 +1,14 @@
+import { schedule as scheduleApi } from './api';
+
+export const schedule = {
+  guests: (scheduleUuid: string, nonMemberUuid: string) => ({
+    queryKey: ['guests', 'guestScheduleList', scheduleUuid, nonMemberUuid],
+    queryFn: () => scheduleApi.guests(scheduleUuid, nonMemberUuid),
+    enabled: false,
+  }),
+
+  member: (scheduleUuid: string) => ({
+    queryKey: ['memberScheduleList', scheduleUuid],
+    queryFn: () => scheduleApi.member(scheduleUuid),
+  }),
+} as const;

--- a/src/apis/schedule/type.ts
+++ b/src/apis/schedule/type.ts
@@ -1,3 +1,12 @@
+import { Schedule } from '../../types/schedule';
 export type CreateScheduleResponse = {
   scheduleUuid: string;
+};
+
+export type ScheduleTimeResponse = {
+  scheduleNickname: string;
+  scheduleUuid: string;
+  meetingStartDate: string;
+  meetingEndDate: string;
+  dateOfScheduleList: Schedule[];
 };

--- a/src/components/common/TimeRangePicker/index.tsx
+++ b/src/components/common/TimeRangePicker/index.tsx
@@ -86,8 +86,6 @@ export const TimeRangePicker = forwardRef<HTMLDivElement, Props>(
           const isGroupStart = isGroupBoundary(index, true);
           const isGroupEnd = isGroupBoundary(index, false);
 
-          console.log('intensity', intensity);
-
           return (
             <TimeBoxSelector
               key={index}

--- a/src/components/features/CreateScheduleForm/ScheduleInputForm.tsx
+++ b/src/components/features/CreateScheduleForm/ScheduleInputForm.tsx
@@ -14,7 +14,14 @@ import { ScheduleInputFormProps } from './types';
 import { useSchedule } from '../../../hooks/useSchedule';
 import { ScheduleInput } from '../../common/ScheduleInput/index';
 
-export const ScheduleInputForm = ({ uuid, setValue, onNext, onPrev }: ScheduleInputFormProps) => {
+export const ScheduleInputForm = ({
+  uuid,
+  edit,
+  dateOfScheduleList,
+  setValue,
+  onNext,
+  onPrev,
+}: ScheduleInputFormProps) => {
   const { data: meetingData } = useSuspenseQuery(queries.meeting.info(uuid));
   const [dates] = useState({
     startDate: meetingData.meetingStartDate,
@@ -28,7 +35,7 @@ export const ScheduleInputForm = ({ uuid, setValue, onNext, onPrev }: ScheduleIn
     movePrev,
     handleTimeSlotClick,
     getSelectedTimeRanges,
-  } = useSchedule(dates.startDate, dates.endDate);
+  } = useSchedule(dates.startDate, dates.endDate, edit ? dateOfScheduleList : undefined);
 
   useEffect(() => {
     const newSchedule = getSelectedTimeRanges();
@@ -42,7 +49,7 @@ export const ScheduleInputForm = ({ uuid, setValue, onNext, onPrev }: ScheduleIn
         header={
           <Header
             left={<IconButton iconName="back" onClick={onPrev} />}
-            middle={<Body2>일정 입력</Body2>}
+            middle={<Body2>일정 {edit ? '수정' : '입력'}</Body2>}
           />
         }
         // TODO : title 없는 경우 수정
@@ -69,7 +76,7 @@ export const ScheduleInputForm = ({ uuid, setValue, onNext, onPrev }: ScheduleIn
       />
 
       <FixedBottomButton onClick={onNext} disabled={getSelectedTimeRanges().length === 0}>
-        확인
+        {edit ? '수정' : '확인'}
       </FixedBottomButton>
     </>
   );

--- a/src/components/features/CreateScheduleForm/types.ts
+++ b/src/components/features/CreateScheduleForm/types.ts
@@ -12,5 +12,7 @@ export type NickNameFormProps = FormProps<{
 
 export type ScheduleInputFormProps = FormProps<{
   uuid: string;
+  edit: boolean;
+  dateOfScheduleList?: Schedule[];
   setValue: (schedule: Schedule[]) => void;
 }>;

--- a/src/components/features/EditScheduleForm/EditScheduleContent.tsx
+++ b/src/components/features/EditScheduleForm/EditScheduleContent.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { Navigate, type NavigateFunction } from 'react-router-dom';
+import { type NavigateFunction } from 'react-router-dom';
 
 import { mutations, queries } from '@/apis';
 import { Button } from '@/components/common/Button';

--- a/src/components/features/EditScheduleForm/EditScheduleContent.tsx
+++ b/src/components/features/EditScheduleForm/EditScheduleContent.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import type { NavigateFunction } from 'react-router-dom';
+
+import { mutations, queries } from '@/apis';
+import { Button } from '@/components/common/Button';
+import { FlexBox } from '@/components/common/FlexBox';
+import { Modal } from '@/components/common/Modal';
+import { useModal } from '@/components/common/Modal/useModal';
+import { Body2 } from '@/components/common/Typography';
+import { Schedule } from '@/types/schedule';
+
+import { ScheduleInputForm } from '../CreateScheduleForm/ScheduleInputForm';
+
+export type editScheduleContentProps = {
+  uuid: string;
+  accessToken?: string | null;
+  pin: string[];
+  setStep: (step: '식별자입력' | '일정수정') => void;
+  navigate: NavigateFunction;
+};
+
+export const EditScheduleContent = ({
+  uuid,
+  accessToken,
+  pin,
+  setStep,
+  navigate,
+}: editScheduleContentProps) => {
+  const { data: scheduleData, refetch } = useQuery({
+    ...(accessToken
+      ? queries.schedule.member(uuid as string)
+      : queries.schedule.guests(uuid as string, pin.join(''))),
+    enabled: !!accessToken,
+    refetchOnMount: true,
+  });
+
+  const [editSchedule, setEditSchedule] = useState<{ dateOfScheduleList: Schedule[] }>();
+  const { isOpen, openModal, closeModal, modalRef } = useModal();
+
+  const updateSchedule = (value: Schedule[]) => {
+    setEditSchedule({ dateOfScheduleList: value });
+  };
+
+  const editScheduleMutation = useMutation({
+    mutationFn: (data: { dateOfScheduleList: Schedule[] }) => {
+      return accessToken
+        ? mutations.memberSchedule.editMemberSchedule.mutationFn(data, uuid)
+        : mutations.nonMemberSchedule.editNonMemberSchedule.mutationFn(data, uuid, pin.join(''));
+    },
+    onSuccess: () => {
+      refetch();
+      navigate(`/${uuid}`);
+    },
+  });
+
+  const confirmSubmit = () => {
+    if (!uuid || !editSchedule) return;
+    editScheduleMutation.mutate(editSchedule);
+    closeModal();
+  };
+
+  const handleSubmitMeeting = () => {
+    if (!uuid) return;
+    openModal();
+  };
+
+  return (
+    <>
+      {scheduleData?.dateOfScheduleList && (
+        <ScheduleInputForm
+          uuid={uuid}
+          edit={true}
+          dateOfScheduleList={scheduleData?.dateOfScheduleList}
+          onPrev={() => (accessToken ? navigate(`/${uuid}`) : setStep('식별자입력'))}
+          onNext={handleSubmitMeeting}
+          setValue={updateSchedule}
+        />
+      )}
+      <Modal
+        isOpen={isOpen}
+        onClose={closeModal}
+        title=""
+        modalRef={modalRef}
+        showCloseButton={true}
+      >
+        <FlexBox flexDir="column" gap={20}>
+          <Body2>일정을 수정하시겠습니까?</Body2>
+          <FlexBox width="100%" flexDir="row" gap={15}>
+            <Button variant="secondary" height="small" onClick={closeModal}>
+              취소
+            </Button>
+            <Button variant="primary" height="small" onClick={confirmSubmit}>
+              확인
+            </Button>
+          </FlexBox>
+        </FlexBox>
+      </Modal>
+    </>
+  );
+};

--- a/src/components/features/EditScheduleForm/EditScheduleContent.tsx
+++ b/src/components/features/EditScheduleForm/EditScheduleContent.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import type { NavigateFunction } from 'react-router-dom';
+import { Navigate, type NavigateFunction } from 'react-router-dom';
 
 import { mutations, queries } from '@/apis';
 import { Button } from '@/components/common/Button';
@@ -35,6 +35,10 @@ export const EditScheduleContent = ({
     refetchOnMount: true,
   });
 
+  // TODO : 데이터가 없는데 일정 수정에 들어온 경우 메인 페이지로 redirect
+  if (scheduleData?.dateOfScheduleList.length === 0) {
+    navigate(`/${uuid}`);
+  }
   const [editSchedule, setEditSchedule] = useState<{ dateOfScheduleList: Schedule[] }>();
   const { isOpen, openModal, closeModal, modalRef } = useModal();
 

--- a/src/components/features/EditScheduleForm/EditScheduleForm.stories.tsx
+++ b/src/components/features/EditScheduleForm/EditScheduleForm.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { editScheduleStepNames } from '@/constants/scheduleFrom';
 import { useFunnel } from '@/hooks/useFunnel';
+import { usePinState } from '@/hooks/usePinState';
 
 import { EditScheduleInputForm } from './EditScheduleInputForm';
 import { PinInputForm } from './PinInputForm';
@@ -22,12 +23,18 @@ type Story = StoryObj<typeof PinInputForm>;
 export const Basic: Story = {
   render: () => {
     const { Funnel, setStep } = useFunnel(editScheduleStepNames);
+    const { pin, setPin } = usePinState();
 
     return (
       <AppLayout>
         <Funnel>
           <Funnel.Step name="식별자입력">
-            <PinInputForm onPrev={() => {}} onNext={() => setStep('일정수정')} />
+            <PinInputForm
+              pin={pin}
+              setPin={setPin}
+              onPrev={() => {}}
+              onNext={() => setStep('일정수정')}
+            />
           </Funnel.Step>
 
           <Funnel.Step name="일정수정">

--- a/src/components/features/EditScheduleForm/PinInputForm.tsx
+++ b/src/components/features/EditScheduleForm/PinInputForm.tsx
@@ -4,13 +4,11 @@ import { FormLayout } from '@/components/common/FormLayout';
 import { Header } from '@/components/common/Header';
 import { IconButton } from '@/components/common/IconButton';
 import { PinInput } from '@/components/common/PinInput';
-import { usePinState } from '@/hooks/usePinState';
 
-import { FormProps } from './types';
+import { PinProps } from './types';
 
-export const PinInputForm = ({ onPrev, onNext }: FormProps) => {
-  // TODO : 식별자가 일치 하지 않을 경우 다음 페이지 이동 불가. API 연결 필요.
-  const { pin, setPin } = usePinState();
+export const PinInputForm = ({ pin, setPin, onPrev, onNext }: PinProps) => {
+  // TODO : 식별자가 일치 하지 않을 경우 다음 페이지 이동 불가. message 보여주기
   const isPinComplete = pin.some((value) => value === '');
   return (
     <>
@@ -25,7 +23,7 @@ export const PinInputForm = ({ onPrev, onNext }: FormProps) => {
         }
       />
       {/* TODO: 식별자가 존재하지 않을 경우 헬퍼 메시지 노출 + 다음 페이지 이동 불가 */}
-      <FixedBottomButton onClick={() => onNext()} disabled={pin[0] === '' || isPinComplete}>
+      <FixedBottomButton onClick={onNext} disabled={isPinComplete}>
         다음
       </FixedBottomButton>
     </>

--- a/src/components/features/EditScheduleForm/types.ts
+++ b/src/components/features/EditScheduleForm/types.ts
@@ -5,6 +5,11 @@ export type FormProps = {
   onPrev: () => void;
 };
 
+export type PinProps = FormProps & {
+  pin: string[];
+  setPin: (value: string[]) => void;
+};
+
 export type ScheduleEditInputFormProps = FormProps & {
   setValue: (value: Schedule[]) => void;
 };

--- a/src/components/features/TotalScheduleList/TotalScheduleList.tsx
+++ b/src/components/features/TotalScheduleList/TotalScheduleList.tsx
@@ -19,7 +19,7 @@ export const TotalScheduleList = ({ uuid, sortOption }: Props) => {
       gap={10}
       css={css`
         overflow-y: scroll;
-        max-height: 50vh;
+        max-height: 47vh;
       `}
     >
       <FlexBox width="100%" height="100%" gap={10}>

--- a/src/pages/EditSchedule.tsx
+++ b/src/pages/EditSchedule.tsx
@@ -1,41 +1,56 @@
-import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { Suspense, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 
+import { EditScheduleContent } from '@/components/features/EditScheduleForm/EditScheduleContent';
 import { PinInputForm } from '@/components/features/EditScheduleForm/PinInputForm';
 import { editScheduleStepNames } from '@/constants/scheduleFrom';
 import { useFunnel } from '@/hooks/useFunnel';
-import { Schedule } from '@/types/schedule';
-
-import { ScheduleInputForm } from '../components/features/CreateScheduleForm/ScheduleInputForm';
+import { usePinState } from '@/hooks/usePinState';
 
 export const EditSchedule = () => {
   const { uuid } = useParams();
   const { Funnel, setStep } = useFunnel(editScheduleStepNames);
 
-  const [, setEditSchedule] = useState<Schedule[]>();
+  const { pin, setPin } = usePinState();
 
-  const updateSchedule = (value: Schedule[]) => {
-    setEditSchedule(value);
+  const navigate = useNavigate();
+  const accessToken = localStorage.getItem('accessToken');
+
+  useEffect(() => {
+    if (accessToken) {
+      setStep('일정수정');
+    }
+  }, [accessToken, setStep]);
+
+  const handlePinSubmit = async () => {
+    const pinString = pin.join('');
+    if (pinString.length === 6) {
+      setStep('일정수정');
+    }
   };
 
   return (
     <Funnel>
       <Funnel.Step name="식별자입력">
         <PinInputForm
-          // TODO : 일정 목록 페이지로 Navigate
-          onPrev={() => {}}
-          onNext={() => setStep('일정수정')}
+          pin={pin}
+          setPin={setPin}
+          onPrev={() => navigate(`/${uuid}`)}
+          onNext={handlePinSubmit}
         />
       </Funnel.Step>
 
       <Funnel.Step name="일정수정">
-        <ScheduleInputForm
-          uuid={uuid as string}
-          onPrev={() => setStep('식별자입력')}
-          // TODO : 일정 목록 페이지로 Navigate
-          onNext={() => {}}
-          setValue={updateSchedule}
-        />
+        {/* // TODO : fallback 추가 */}
+        <Suspense>
+          <EditScheduleContent
+            uuid={uuid as string}
+            accessToken={accessToken}
+            pin={pin}
+            setStep={setStep}
+            navigate={navigate}
+          />
+        </Suspense>
       </Funnel.Step>
     </Funnel>
   );

--- a/src/pages/NewSchedule.tsx
+++ b/src/pages/NewSchedule.tsx
@@ -47,7 +47,7 @@ export const NewSchedule = () => {
       return mutationFn(data, uuid as string);
     },
     onSuccess: ({ scheduleUuid }) => {
-      navigate(`/${uuid}/share`, { state: { scheduleUuid } });
+      accessToken ? navigate(`/${uuid}`) : navigate(`/${uuid}/share`, { state: { scheduleUuid } });
     },
   });
 
@@ -78,6 +78,7 @@ export const NewSchedule = () => {
         <Funnel.Step name="일정입력">
           <ScheduleInputForm
             uuid={uuid as string}
+            edit={false}
             onPrev={() => (accessToken ? navigate(`/${uuid}`) : setStep('닉네임설정'))}
             onNext={handleSubmitMeeting}
             setValue={(value: Schedule[]) => updateDateOfScheduleList(value)}

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -1,4 +1,7 @@
 export const formatTime = (hour: number) => {
   const formattedHour = (hour + 9).toString().padStart(2, '0');
-  return `${formattedHour}:00`;
+  if (formattedHour == '24') {
+    return `${Number(formattedHour) - 1}:59:59`;
+  }
+  return `${formattedHour}:00:00`;
 };


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #225

## ✨ 작업 내용
- 일정 수정 API 연결했습니다.

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 🙏 기타 참고 사항

- 회원의 일정 수정 시 데이터가 undefined로 초기화 된 이후 데이터가 들어오는 것을 확인했습니다. 따라서 코드에 해당 조건을 추가했습니다.
- 일정 수정페이지로 진입시 200밀리초 동안 빈 화면이 뜹니다. API를 불러오는 동안 생기는 문제 상황 같습니다. `loadingPage`가 있으면 좋을 것 같다고 느꼈습니당.
```
{scheduleData?.dateOfScheduleList && (
  <ScheduleInputForm
    uuid={uuid}
    edit={true}
    dateOfScheduleList={scheduleData?.dateOfScheduleList}
    onPrev={() => (accessToken ? navigate(`/${uuid}`) : setStep('식별자입력'))}
    onNext={handleSubmitMeeting}
    setValue={updateSchedule}
  />
)}
```
<!-- 없다면 적지 않으셔도 됩니다. -->
