### PR TITLE
[FEAT] 일정 입력/수정 시 Modal 내 navigate 수정

### DIFF
--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -2,7 +2,7 @@ import { ModalContent, StyledModal } from './Modal.styled';
 import { Props } from './Modal.types';
 
 import { FlexBox } from '../FlexBox';
-import { Icon } from '../Icon';
+import { IconButton } from '../IconButton';
 import { Head4 } from '../Typography';
 
 export const Modal = ({
@@ -20,7 +20,7 @@ export const Modal = ({
       <ModalContent ref={modalRef}>
         <FlexBox flexDir="row" justifyContent="space-between" alignItems="center">
           <Head4>{title}</Head4>
-          {showCloseButton && <Icon onClick={onClose} name="close" size={15} />}
+          {showCloseButton && <IconButton onClick={onClose} iconName="close" size={15} />}
         </FlexBox>
         {children}
       </ModalContent>

--- a/src/components/features/EditScheduleForm/EditScheduleContent.tsx
+++ b/src/components/features/EditScheduleForm/EditScheduleContent.tsx
@@ -8,6 +8,7 @@ import { FlexBox } from '@/components/common/FlexBox';
 import { Modal } from '@/components/common/Modal';
 import { useModal } from '@/components/common/Modal/useModal';
 import { Body2 } from '@/components/common/Typography';
+import { scheduleModalNavigateNames } from '@/constants/scheduleForm';
 import { Schedule } from '@/types/schedule';
 
 import { ScheduleInputForm } from '../CreateScheduleForm/ScheduleInputForm';
@@ -39,6 +40,7 @@ export const EditScheduleContent = ({
   if (scheduleData?.dateOfScheduleList.length === 0) {
     navigate(`/${uuid}`);
   }
+
   const [editSchedule, setEditSchedule] = useState<{ dateOfScheduleList: Schedule[] }>();
   const { isOpen, openModal, closeModal, modalRef } = useModal();
 
@@ -54,19 +56,22 @@ export const EditScheduleContent = ({
     },
     onSuccess: () => {
       refetch();
-      navigate(`/${uuid}`);
+      openModal();
     },
   });
 
-  const confirmSubmit = () => {
+  const handleSubmitMeeting = () => {
     if (!uuid || !editSchedule) return;
     editScheduleMutation.mutate(editSchedule);
-    closeModal();
+    openModal();
   };
 
-  const handleSubmitMeeting = () => {
-    if (!uuid) return;
-    openModal();
+  const handelNavigateResultOrHome = (value: string) => {
+    closeModal();
+    if (value === scheduleModalNavigateNames.HOME) {
+      navigate(`/${uuid}`);
+    }
+    navigate(`/${uuid}/schedules`);
   };
 
   return (
@@ -89,13 +94,21 @@ export const EditScheduleContent = ({
         showCloseButton={true}
       >
         <FlexBox flexDir="column" gap={20}>
-          <Body2>일정을 수정하시겠습니까?</Body2>
+          <Body2>째깍! 일정 수정이 완료되었어요.</Body2>
           <FlexBox width="100%" flexDir="row" gap={15}>
-            <Button variant="secondary" height="small" onClick={closeModal}>
-              취소
+            <Button
+              variant="tertiary"
+              height="small"
+              onClick={() => handelNavigateResultOrHome(scheduleModalNavigateNames.HOME)}
+            >
+              {scheduleModalNavigateNames.HOME}
             </Button>
-            <Button variant="primary" height="small" onClick={confirmSubmit}>
-              확인
+            <Button
+              variant="primary"
+              height="small"
+              onClick={() => handelNavigateResultOrHome(scheduleModalNavigateNames.RESULT)}
+            >
+              {scheduleModalNavigateNames.RESULT}
             </Button>
           </FlexBox>
         </FlexBox>

--- a/src/components/features/EditScheduleForm/EditScheduleForm.stories.tsx
+++ b/src/components/features/EditScheduleForm/EditScheduleForm.stories.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-exports */
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { editScheduleStepNames } from '@/constants/scheduleFrom';
+import { editScheduleStepNames } from '@/constants/scheduleForm';
 import { useFunnel } from '@/hooks/useFunnel';
 import { usePinState } from '@/hooks/usePinState';
 

--- a/src/constants/scheduleForm.ts
+++ b/src/constants/scheduleForm.ts
@@ -1,2 +1,8 @@
 export const newScheduleStepNames = ['닉네임설정', '일정입력'] as const;
 export const editScheduleStepNames = ['식별자입력', '일정수정'] as const;
+
+export const scheduleModalNavigateNames = {
+  HOME: '홈으로',
+  EDIT: '수정하기',
+  RESULT: '결과 확인하기',
+};

--- a/src/pages/EditSchedule.tsx
+++ b/src/pages/EditSchedule.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { EditScheduleContent } from '@/components/features/EditScheduleForm/EditScheduleContent';
 import { PinInputForm } from '@/components/features/EditScheduleForm/PinInputForm';
-import { editScheduleStepNames } from '@/constants/scheduleFrom';
+import { editScheduleStepNames } from '@/constants/scheduleForm';
 import { useFunnel } from '@/hooks/useFunnel';
 import { usePinState } from '@/hooks/usePinState';
 

--- a/src/pages/NewSchedule.tsx
+++ b/src/pages/NewSchedule.tsx
@@ -8,7 +8,7 @@ import { FlexBox } from '@/components/common/FlexBox';
 import { Modal } from '@/components/common/Modal';
 import { useModal } from '@/components/common/Modal/useModal';
 import { Body2 } from '@/components/common/Typography';
-import { newScheduleStepNames } from '@/constants/scheduleFrom';
+import { newScheduleStepNames, scheduleModalNavigateNames } from '@/constants/scheduleForm';
 import { useFunnel } from '@/hooks/useFunnel';
 import { Schedule, newSchedule } from '@/types/schedule';
 
@@ -47,20 +47,23 @@ export const NewSchedule = () => {
       return mutationFn(data, uuid as string);
     },
     onSuccess: ({ scheduleUuid }) => {
-      accessToken ? navigate(`/${uuid}`) : navigate(`/${uuid}/share`, { state: { scheduleUuid } });
+      accessToken ? openModal() : navigate(`/${uuid}/share`, { state: { scheduleUuid } });
     },
   });
 
   const handleSubmitMeeting = () => {
     if (!uuid) return;
-    openModal();
-  };
-
-  const confirmSubmit = () => {
-    if (!uuid) return;
     const data = accessToken ? schedule : { ...schedule, nickname: nickName };
     createScheduleMutation.mutate(data);
+  };
+
+  const handelNavigateResultOrEdit = (value: string) => {
+    if (!uuid) return;
     closeModal();
+    if (value == scheduleModalNavigateNames.RESULT) {
+      return navigate(`/${uuid}/schedules`);
+    }
+    return navigate(`/${uuid}/edit`);
   };
 
   return (
@@ -93,13 +96,21 @@ export const NewSchedule = () => {
         showCloseButton={true}
       >
         <FlexBox flexDir="column" gap={20}>
-          <Body2>일정을 저장하시겠습니까?</Body2>
+          <Body2>쨰깍! 일정이 생성되었어요!</Body2>
           <FlexBox width="100%" flexDir="row" gap={15}>
-            <Button variant="secondary" height="small" onClick={closeModal}>
-              취소
+            <Button
+              variant="tertiary"
+              height="small"
+              onClick={() => handelNavigateResultOrEdit(scheduleModalNavigateNames.EDIT)}
+            >
+              {scheduleModalNavigateNames.EDIT}
             </Button>
-            <Button variant="primary" height="small" onClick={confirmSubmit}>
-              확인
+            <Button
+              variant="primary"
+              height="small"
+              onClick={() => handelNavigateResultOrEdit(scheduleModalNavigateNames.RESULT)}
+            >
+              {scheduleModalNavigateNames.RESULT}
             </Button>
           </FlexBox>
         </FlexBox>


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #235

## ✨ 작업 내용

- 일정 입력/수정 시 Modal 내 navigate 수정했습니다.


<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 🙏 기타 참고 사항

**공통**
- 일정 수정 시 모달 내 `홈으로/결과 확인하기` 버튼 노출

**회원**
1. 일정 생성 시 모달 내 `수정/결과 확인` 버튼 노출

**비회원**
1. 일정 생성 시 Pin 번호 공유하는 페이지 이동
