### PR TITLE
[FEAT] 랜딩 페이지 시작하기 버튼을 카카오톡 로그인 버튼으로 교체

### DIFF
--- a/src/components/features/KakaoLoginButton/index.tsx
+++ b/src/components/features/KakaoLoginButton/index.tsx
@@ -10,7 +10,7 @@ export const KakaoLoginButton = ({ ...props }: ComponentPropsWithoutRef<'a'>) =>
     <KakaoButtonContainer {...props}>
       <FlexBox flexDir="row" alignItems="center" justifyContent="center" gap={8}>
         <Icon name="kakaotalk2" size={18} />
-        카카오톡으로 로그인
+        카카오 계정으로 시작하기
       </FlexBox>
     </KakaoButtonContainer>
   );

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,13 +1,14 @@
 import styled from '@emotion/styled';
 import { motion } from 'framer-motion';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 
-import { FixedBottomButton as FBB } from '@/components/common/FixedBottomButton';
 import { FlexBox } from '@/components/common/FlexBox';
 import { Icon } from '@/components/common/Icon';
 import { LandingContentLayout } from '@/components/common/LandingContentLayout';
 import { Body1 } from '@/components/common/Typography';
+import { KakaoLoginButton } from '@/components/features/KakaoLoginButton';
 import { useAuth } from '@/hooks/useAuth';
+import { ENV } from '@/lib/env';
 import { colors } from '@/styles/global';
 
 /**
@@ -15,7 +16,6 @@ import { colors } from '@/styles/global';
  */
 export const Landing = () => {
   const { isAuthenticated } = useAuth();
-  const navigate = useNavigate();
 
   if (isAuthenticated) {
     return <Navigate to="/meeting" />;
@@ -75,21 +75,17 @@ export const Landing = () => {
         </Body1>
       </FlexBox>
 
-      <FixedBottomButton onClick={() => navigate('/login')}>시작하기</FixedBottomButton>
+      <StyledKakaoLoginButton href={`${ENV.API_BASE_URL}/auth/oauth2/kakao?redirect=/meeting`} />
     </FlexBox>
   );
 };
 
-const FixedBottomButton = styled(FBB)`
-  position: sticky;
-  background-color: ${colors.WH};
-  color: ${colors.purple};
-  font-weight: 800;
-
-  @media (hover: hover) and (pointer: fine) {
-    &:hover:not(:disabled) {
-      background-color: ${colors.GY5};
-      color: ${colors.purple};
-    }
-  }
+const StyledKakaoLoginButton = styled(KakaoLoginButton)`
+  position: fixed;
+  bottom: 20px;
+  left: auto;
+  right: auto;
+  width: 100%;
+  max-width: 390px;
+  z-index: 999;
 `;


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #255 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

<img width="427" alt="스크린샷 2024-11-05 오후 8 17 35" src="https://github.com/user-attachments/assets/f56bdb69-f8fa-4624-803a-553362f138a4">

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
