### PR TITLE
[BUGFIX] 일정 입력 마감 기한 선택지 노출되도록

### DIFF
--- a/src/components/features/CreateMeetingForm/DueDateForm.tsx
+++ b/src/components/features/CreateMeetingForm/DueDateForm.tsx
@@ -18,31 +18,35 @@ export const DueDateForm = ({ context, onNext, onPrev }: Props<MeetingForm['dueD
 
   const [selectedDueDate, setSelectedDueDate] = useState(dueDateTime);
 
-  const accessDate = dayjs().format('YYYY-MM-DDTHH'); // NOTE: 해당 페이지의 접속 날짜를 기준으로 +n일을 계산하기 위함
+  const accessDate = dayjs().format('YYYY-MM-DD'); // NOTE: 해당 페이지의 접속 날짜를 기준으로 +n일을 계산하기 위함
   const endDateOf = useMemo(
     () => ({
       // TODO 유틸화
-      오늘: dayjs(accessDate).endOf('day').format('YYYY-MM-DDTHH:mm:ss'),
-      내일: dayjs(accessDate).add(1, 'day').endOf('day').format('YYYY-MM-DDTHH:mm:ss'),
-      '3일': dayjs(accessDate).add(3, 'day').endOf('day').format('YYYY-MM-DDTHH:mm:ss'),
-      '5일': dayjs(accessDate).add(5, 'day').endOf('day').format('YYYY-MM-DDTHH:mm:ss'),
+      오늘: dayjs(accessDate).endOf('day').format('YYYY-MM-DD'),
+      내일: dayjs(accessDate).add(1, 'day').endOf('day').format('YYYY-MM-DD'),
+      '3일': dayjs(accessDate).add(3, 'day').endOf('day').format('YYYY-MM-DD'),
+      '5일': dayjs(accessDate).add(5, 'day').endOf('day').format('YYYY-MM-DD'),
     }),
     [accessDate]
   );
   const endDates = Object.entries(endDateOf).filter(([, value]) =>
-    dayjs(value).isBefore(dayjs(meetingStartDate))
+    dayjs(value).isSameOrBefore(dayjs(meetingStartDate))
   );
 
   return (
     <>
       <FormLayout
         header={<FormLayout.Header progress={progress} maxProgress={maxProgress} onPrev={onPrev} />}
-        title={`일정 입력 마감 기한을\n기입해 주세요`}
+        title={`일정 입력 마감 기한을\n선택해 주세요`}
         content={
           <FlexBox width="100%" padding="78px 0">
             <Switch selectedValue={selectedDueDate} onChange={setSelectedDueDate}>
               {endDates.map(([label, value]) => (
-                <Switch.Button key={value} label={label} value={value} />
+                <Switch.Button
+                  key={value}
+                  label={label}
+                  value={dayjs(value).format('YYYY-MM-DDTHH:mm:ss')}
+                />
               ))}
             </Switch>
           </FlexBox>


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #271 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

![Nov-06-2024 01-03-00](https://github.com/user-attachments/assets/eb42dd6f-c310-4639-a0bd-2c5d541a0a44)

- 원인
  - 날짜만 따지면 되는데, 시간까지 비교해서 발생한 문제
    - e.g. 모임 일정 시작 시간(meetingStartDate)은 `2024-11-06T00:00:00`인데, 일정 입력 마감 기한 폼에 접근한 시간(accessDate)는 2024-11-06T01:01:01이라면 접근한 시간이 더 늦어서 `오늘` 선택지가 노출되지 않음
- 해결
  - 시간 떼고 비교
  - 서버에 시간을 포함한 YYYY-MM-DDThh:mm:ss 포맷으로 요청을 보내야해서, 스위치 버튼의 value 값에 포맷팅해주었음

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
