### PR TITLE
[BUGFIX] reissue 무한 요청 동작 픽스

### DIFF
--- a/src/apis/member/api.ts
+++ b/src/apis/member/api.ts
@@ -2,15 +2,17 @@ import { ENDPOINT } from '@/constants/endpoint';
 import { instance } from '@/lib/axios';
 import { Meeting } from '@/types/meeting';
 
-import { CheckResponse } from './type';
+import { CheckResponse, ReissueResponse } from './type';
 
 export const member = {
   /**
    * @description 토큰 재발급
    */
   reissue: async () => {
-    const response = await instance.get(ENDPOINT.MEMBER.REISSUE, { withCredentials: true });
-    localStorage.setItem('accessToken', response.headers.authorization);
+    const response = await instance.get<ReissueResponse>(ENDPOINT.MEMBER.REISSUE, {
+      withCredentials: true,
+    });
+    localStorage.setItem('accessToken', response.data.accessToken);
     return response.data;
   },
   /**

--- a/src/apis/member/type.ts
+++ b/src/apis/member/type.ts
@@ -1,3 +1,7 @@
 export type CheckResponse = {
   isAuthenticated: boolean;
 };
+
+export type ReissueResponse = {
+  accessToken: string;
+};

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -5,7 +5,7 @@ import { queries } from '@/apis';
 export const useAuth = () => {
   const accessToken = localStorage.getItem('accessToken') ?? '';
 
-  const { data } = useSuspenseQuery({ ...queries.member.check(accessToken) });
+  const { data } = useSuspenseQuery({ ...queries.member.check(accessToken), retry: 0 });
 
   const isAuthenticated = data.isAuthenticated;
 

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,5 +1,7 @@
 import axios, { AxiosError } from 'axios';
 
+import { ReissueResponse } from '@/apis/member/type';
+
 import { ENV } from './env';
 
 export const instance = axios.create({
@@ -7,35 +9,34 @@ export const instance = axios.create({
   timeout: 5000,
   headers: {
     'Content-Type': 'application/json',
-    _retry: '0',
   },
 });
 
 instance.interceptors.response.use(
   function onFulFilled(response) {
+    if (response.status === 200 && response.config.url === '/auth/reissue') {
+      const newAccessToken = response.data.accessToken;
+      localStorage.setItem('accessToken', newAccessToken);
+    }
     return response;
   },
   async function onRejected(error: AxiosError) {
-    const originalRequest = error.config;
-    if (
-      error.response?.status === 401 &&
-      originalRequest &&
-      originalRequest.headers._retry === '0'
-    ) {
-      try {
-        const response = await instance.get('/auth/reissue', { withCredentials: true }); // 순환 참조 방지 위해 apis 함수 사용 X
-        const newAccessToken = response.headers.Authorization;
-        localStorage.setItem('accessToken', newAccessToken);
+    console.log('rejected error', error);
+    if (error.response?.status === 401 && error.response?.config.url === '/auth/check') {
+      const staledAccessToken = localStorage.getItem('accessToken');
+      localStorage.removeItem('accessToken');
 
-        originalRequest.withCredentials = true;
-        originalRequest.headers.Authorization = newAccessToken;
-        originalRequest.headers._retry = '1';
-
-        return await instance(originalRequest);
-      } catch (reissueError) {
-        alert('로그인이 필요합니다.');
-        return Promise.reject(reissueError);
-      }
+      instance.get<ReissueResponse>('/auth/reissue', {
+        withCredentials: true,
+        headers: { Authorization: staledAccessToken },
+      });
     }
+
+    if (error.response?.status === 418 && error.response?.config.url === '/auth/reissue') {
+      localStorage.removeItem('accessToken');
+      if (confirm('로그인이 필요합니다.')) location.href = '/';
+    }
+
+    return Promise.reject(error);
   }
 );

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -21,7 +21,6 @@ instance.interceptors.response.use(
     return response;
   },
   async function onRejected(error: AxiosError) {
-    console.log('rejected error', error);
     if (error.response?.status === 401 && error.response?.config.url === '/auth/check') {
       const staledAccessToken = localStorage.getItem('accessToken');
       localStorage.removeItem('accessToken');

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,9 +1,11 @@
 import axios, { AxiosError } from 'axios';
 
 import { ReissueResponse } from '@/apis/member/type';
+import { ENDPOINT } from '@/constants/endpoint';
 
 import { ENV } from './env';
 
+const ACCESS_TOKEN = 'accessToken';
 export const instance = axios.create({
   baseURL: ENV.API_BASE_URL,
   timeout: 5000,
@@ -14,25 +16,25 @@ export const instance = axios.create({
 
 instance.interceptors.response.use(
   function onFulFilled(response) {
-    if (response.status === 200 && response.config.url === '/auth/reissue') {
+    if (response.status === 200 && response.config.url === ENDPOINT.MEMBER.REISSUE) {
       const newAccessToken = response.data.accessToken;
-      localStorage.setItem('accessToken', newAccessToken);
+      localStorage.setItem(ACCESS_TOKEN, newAccessToken);
     }
     return response;
   },
   async function onRejected(error: AxiosError) {
-    if (error.response?.status === 401 && error.response?.config.url === '/auth/check') {
-      const staledAccessToken = localStorage.getItem('accessToken');
-      localStorage.removeItem('accessToken');
+    if (error.response?.status === 401 && error.response?.config.url === ENDPOINT.MEMBER.CHECK) {
+      const staledAccessToken = localStorage.getItem(ACCESS_TOKEN);
+      localStorage.removeItem(ACCESS_TOKEN);
 
-      instance.get<ReissueResponse>('/auth/reissue', {
+      instance.get<ReissueResponse>(ENDPOINT.MEMBER.REISSUE, {
         withCredentials: true,
         headers: { Authorization: staledAccessToken },
       });
     }
 
-    if (error.response?.status === 418 && error.response?.config.url === '/auth/reissue') {
-      localStorage.removeItem('accessToken');
+    if (error.response?.status === 418 && error.response?.config.url === ENDPOINT.MEMBER.REISSUE) {
+      localStorage.removeItem(ACCESS_TOKEN);
       if (confirm('로그인이 필요합니다.')) location.href = '/';
     }
 


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #278 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

- accessToken을 response의 헤더로 받지 않고 body로 받도록 수정되었습니다.
- 인터셉터에 의해 무한 reissue 요청이 발생하지 않도록 인터셉터 로직을 수정합니다.

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
