### PR TITLE
[FIX] 일정 조회 API 경로 수정

### DIFF
--- a/src/apis/schedule/api.ts
+++ b/src/apis/schedule/api.ts
@@ -70,7 +70,7 @@ export const schedule = {
    */
   guests: async (scheduleUuid: string, nonMemberUuid: string) => {
     const response = await instance.get<ScheduleTimeResponse>(
-      `/meetings/${scheduleUuid}/schedules/guests?scheduleUuid=${nonMemberUuid}`
+      `/meetings/${scheduleUuid}/schedules/guests/${nonMemberUuid}`
     );
     return response.data;
   },

--- a/src/components/features/CreateMeetingForm/DueDateForm.tsx
+++ b/src/components/features/CreateMeetingForm/DueDateForm.tsx
@@ -30,7 +30,7 @@ export const DueDateForm = ({ context, onNext, onPrev }: Props<MeetingForm['dueD
     [accessDate]
   );
   const endDates = Object.entries(endDateOf).filter(([, value]) =>
-    dayjs(value).isSameOrBefore(dayjs(meetingStartDate))
+    dayjs(value).startOf('day').isSameOrBefore(dayjs(meetingStartDate))
   );
 
   return (


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #282 

## ✨ 작업 내용

- 일정 조회 API 경로 수정했습니다.
- 모집 마감 기한 필터링 로직에서 시간까지 고려되어 시작 날짜가 오늘인 경우 `dayjs('2024-12-03T23:59:59').isSameOrBefore(dayjs('2024-12-03'))` 조건이 false로 평가되는 문제 상황이 있었습니다. (시간이 존재 하지 않을 경우 00:00:00이 적용됩니다.)
- 날짜만 비교하도록 `startOf('day')` 사용했습니다!
<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
