### PR TITLE
[FEAT] Skeleton 컴포넌트, 스토리북 

### DIFF
--- a/src/components/common/Skeleton/Skeleton.stories.tsx
+++ b/src/components/common/Skeleton/Skeleton.stories.tsx
@@ -1,0 +1,45 @@
+/* eslint-disable no-restricted-exports */
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Skeleton } from '.';
+import { FlexBox } from '../FlexBox';
+
+const meta = {
+  title: 'components/common/Skeleton',
+  component: Skeleton,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+type Story = StoryObj<typeof Skeleton>;
+
+export const Basic: Story = {
+  args: {
+    layout: 'box',
+    width: '100%',
+    height: '100%',
+  },
+  argTypes: {
+    layout: {
+      control: {
+        type: 'inline-radio',
+      },
+      options: ['text', 'box'],
+    },
+    width: {
+      control: {
+        type: 'text',
+      },
+    },
+    height: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
+  render: (args) => (
+    <FlexBox justifyContent="space-between" height="10rem">
+      <Skeleton {...args} />
+    </FlexBox>
+  ),
+};

--- a/src/components/common/Skeleton/Skeleton.styled.ts
+++ b/src/components/common/Skeleton/Skeleton.styled.ts
@@ -1,0 +1,45 @@
+import { keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import { Props } from './Skeleton.types';
+
+export const pulseKeyframes = keyframes`
+  50% {
+    opacity: .5;
+  }
+`;
+
+export const StyledSkeletonContainer = styled.div<Props>`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
+`;
+
+export const StyledTextSkeletonContainer = styled.div<Props>`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
+`;
+
+export const StyledTextLine = styled.div<{ width: string }>`
+  height: 1rem;
+  width: ${({ width }) => width};
+  background-color: #f3f4f6;
+  border-radius: 0.25rem;
+  animation: ${pulseKeyframes} 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+`;
+
+export const StyledBoxSkeleton = styled.div`
+  width: 100%;
+  height: 100%;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  background-color: #f3f4f6;
+  border-radius: 0.5rem;
+  animation: ${pulseKeyframes} 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+`;

--- a/src/components/common/Skeleton/Skeleton.types.ts
+++ b/src/components/common/Skeleton/Skeleton.types.ts
@@ -1,0 +1,17 @@
+export type Props = {
+  /**
+   * The layout of the skeleton.
+   * @default 'box'
+   */
+  layout?: 'text' | 'box';
+  /**
+   * The width of the skeleton.
+   * @default '100%'
+   */
+  width: string;
+  /**
+   * The height of the skeleton.
+   * @default '100%'
+   */
+  height: string;
+};

--- a/src/components/common/Skeleton/index.tsx
+++ b/src/components/common/Skeleton/index.tsx
@@ -1,0 +1,26 @@
+import {
+  StyledBoxSkeleton,
+  StyledSkeletonContainer,
+  StyledTextLine,
+  StyledTextSkeletonContainer,
+} from './Skeleton.styled';
+import { Props } from './Skeleton.types';
+
+const TEXT_LINE_WIDTH = ['30%', '60%', '90%', '80%'];
+export const Skeleton = ({ layout = 'box', width = '100%', height = '100%', ...props }: Props) => {
+  if (layout === 'text') {
+    return (
+      <StyledTextSkeletonContainer width={width} height={height} {...props}>
+        {TEXT_LINE_WIDTH.map((width) => (
+          <StyledTextLine key={width} width={width} />
+        ))}
+      </StyledTextSkeletonContainer>
+    );
+  }
+
+  return (
+    <StyledSkeletonContainer width={width} height={height} {...props}>
+      <StyledBoxSkeleton />
+    </StyledSkeletonContainer>
+  );
+};

--- a/src/components/features/TotalScheduleList/TotalScheduleList.tsx
+++ b/src/components/features/TotalScheduleList/TotalScheduleList.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { css } from '@emotion/react';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 
 import { queries } from '@/apis';
 import { FlexBox } from '@/components/common/FlexBox';
@@ -18,7 +18,7 @@ export const TotalScheduleList = ({ uuid, sortOption }: Props) => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useInfiniteQuery({
+  } = useSuspenseInfiniteQuery({
     ...queries.meeting.times(uuid, sortOption),
     initialPageParam: { page: 0, requestTime: '' },
     getNextPageParam: (lastPage) => {

--- a/src/pages/EditSchedule.tsx
+++ b/src/pages/EditSchedule.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -71,18 +71,15 @@ export const EditSchedule = () => {
       </Funnel.Step>
 
       <Funnel.Step name="일정수정">
-        {/* // TODO : fallback 추가 */}
-        <Suspense>
-          <EditScheduleContent
-            uuid={uuid as string}
-            accessToken={accessToken}
-            data={scheduleData?.dateOfScheduleList as Schedule[]}
-            pin={pin}
-            setStep={setStep}
-            refetch={refetch}
-            navigate={navigate}
-          />
-        </Suspense>
+        <EditScheduleContent
+          uuid={uuid as string}
+          accessToken={accessToken}
+          data={scheduleData?.dateOfScheduleList as Schedule[]}
+          pin={pin}
+          setStep={setStep}
+          refetch={refetch}
+          navigate={navigate}
+        />
       </Funnel.Step>
     </Funnel>
   );

--- a/src/pages/MeetingDetail.tsx
+++ b/src/pages/MeetingDetail.tsx
@@ -4,6 +4,7 @@ import { useParams, useNavigate, Navigate } from 'react-router-dom';
 
 import { FlexBox } from '@/components/common/FlexBox';
 import { ScheduleLayout } from '@/components/common/ScheduleLayout';
+import { Skeleton } from '@/components/common/Skeleton';
 import { Body3 } from '@/components/common/Typography';
 import { MeetingInfo } from '@/components/features/MeetingDetail/MeetingInfo';
 import { MemberList } from '@/components/features/MeetingDetail/MemberList';
@@ -31,14 +32,31 @@ export const MeetingDetail = () => {
         <meta property="og:image" content="https://ifh.cc/g/38gbOb.jpg" />
       </Helmet>
       <ScheduleLayout>
-        {/* TODO Suspense fallback */}
-        <Suspense>
+        <Suspense
+          fallback={
+            <FlexBox width="100%" height="100%" padding="50px 20px 20px 20px">
+              <Skeleton layout="text" width="100%" height="170px" />
+            </FlexBox>
+          }
+        >
           <MeetingInfo uuid={uuid} />
         </Suspense>
-        <Suspense>
+        <Suspense
+          fallback={
+            <FlexBox width="100%" height="100%" padding="10px 20px">
+              <Skeleton width="100%" height="200px" />
+            </FlexBox>
+          }
+        >
           <MemberScheduleCard uuid={uuid} onNavigate={navigate} />
         </Suspense>
-        <Suspense>
+        <Suspense
+          fallback={
+            <FlexBox width="100%" height="100%" padding="0px 20px">
+              <Skeleton width="100%" height="160px" />
+            </FlexBox>
+          }
+        >
           <MemberList uuid={uuid} />
         </Suspense>
         {!accessToken && (

--- a/src/pages/TotalSchedule.tsx
+++ b/src/pages/TotalSchedule.tsx
@@ -12,6 +12,7 @@ import { FormLayout } from '@/components/common/FormLayout';
 import { Header } from '@/components/common/Header';
 import { IconButton } from '@/components/common/IconButton';
 import { SegmentedControl } from '@/components/common/SegmentedControl';
+import { Skeleton } from '@/components/common/Skeleton';
 import { Body2 } from '@/components/common/Typography';
 import { TotalScheduleList } from '@/components/features/TotalScheduleList/TotalScheduleList';
 import { colors } from '@/styles/global';
@@ -32,8 +33,6 @@ export const TotalSchedule = () => {
           <Header
             left={<IconButton iconName="back" onClick={() => navigate(`/${uuid}`)} />}
             middle={<Body2>전체보기</Body2>}
-            // TODO : MY페이지 이동
-            right={<IconButton iconName="user" />}
           />
         }
         // TODO: 추후 title 제거
@@ -74,7 +73,15 @@ export const TotalSchedule = () => {
                 <Border borderStyle="dashed" color="GY5" />
               </FlexBox>
 
-              <Suspense>
+              <Suspense
+                fallback={
+                  <FlexBox gap={10}>
+                    {Array.from({ length: 4 }).map((_, index) => (
+                      <Skeleton key={index} layout="box" width="100%" height="110px" />
+                    ))}
+                  </FlexBox>
+                }
+              >
                 <TotalScheduleList uuid={uuid as string} sortOption={sortOption} />
               </Suspense>
             </FlexBox>


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #281 

## ✨ 작업 내용

- `Skeleton` 컴포넌트, 스토리북 구현했습니다.
- `Skeleton`의 layout을 `text` 와 `box`로 구분하고, 의견 주셨던 `width`와 `heigth`을 props로 받도록 구현했습니다.
- 모임 전체 조회에서 사용하는 각 컴포넌트 레이아웃에 padding 값이 설정되어 있어, `Skeleton`에도 동일한 padding을 적용하는 것이 적합하다고 판단했습니다. 이때, `Skeleton`에 별도의 padding props를 추가하지 않고, `FlexBox`의 padding 값을 활용하여 구현했습니다!
- 일정 수정의 경우 스켈레톤 보다는 로딩 인디케이터가 더 적절할 것 같아 `Suspense` 뺐습니다! 
<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
<img width="227" alt="스크린샷 2024-12-21 오후 11 29 07" src="https://github.com/user-attachments/assets/413d00a2-c9c6-4a07-a8b1-0f705927676d" />
<img width="223" alt="스크린샷 2024-12-21 오후 11 43 23" src="https://github.com/user-attachments/assets/3c271d4c-82d9-4882-91de-ed4a9ce78ebd" />


